### PR TITLE
data: weekly Money Tools refresh 2026-06-26 (spot + FX)

### DIFF
--- a/apps/web/src/lib/market-data/__tests__/formulas.test.ts
+++ b/apps/web/src/lib/market-data/__tests__/formulas.test.ts
@@ -429,15 +429,16 @@ describe('Phase A — inflation cumulative-since-2010 fields', () => {
   });
 });
 
-describe('Phase A (2026-05-16) / Phase C (2026-05-23) — asset prices refreshed', () => {
-  it('BTC spot matches Phase C live May 22 2026 anchor (Fortune $77,262)', () => {
-    // Phase C: refreshed from $80,000 (Phase A May 15 anchor) to $77,262
-    // (Fortune May 21 09:15 ET — Phase A reconciliation reference).
-    expect(FALLBACK_MARKET_DATA.assetPrices.crypto.BTC).toBe(77262);
+describe('asset prices — weekly refresh anchor (tools-data-weekly-runbook.md)', () => {
+  it('BTC spot matches the 2026-06-26 live anchor (CoinGecko/Yahoo $59,986)', () => {
+    // Weekly refresh 2026-06-26: risk-off leg, refreshed from $77,262
+    // (Phase C May 22 anchor) to $59,986 (Yahoo BTC-USD 2026-06-26 close,
+    // CoinGecko cross-check $60,000). Update this anchor on each weekly refresh.
+    expect(FALLBACK_MARKET_DATA.assetPrices.crypto.BTC).toBe(59986);
   });
 
-  it('updatedAt stamp reflects Phase C 2026-05-22 refresh', () => {
-    expect(FALLBACK_MARKET_DATA.assetPrices.updatedAt).toBe('2026-05-22T00:00:00Z');
+  it('updatedAt stamp reflects the 2026-06-26 weekly refresh', () => {
+    expect(FALLBACK_MARKET_DATA.assetPrices.updatedAt).toBe('2026-06-26T00:00:00Z');
   });
 });
 

--- a/apps/web/src/lib/market-data/constants.ts
+++ b/apps/web/src/lib/market-data/constants.ts
@@ -80,10 +80,13 @@ export const FALLBACK_MARKET_DATA: MarketDataSnapshot = {
   // Phase C (TOOLS_IMPROVEMENT.md, 2026-05-23): refreshed to May-21/22 live spots
   // per Phase A authoritative numbers (Fortune BTC, TradingEconomics gold/TLT).
   assetPrices: {
-    crypto: { BTC: 77262, ETH: 2300, SOL: 152, SUI: 2.85, TRX: 0.21 }, // BTC was 80000
-    etfs: { SPYx: 745, QQQx: 717, IWMon: 234 }, // SPY/QQQ updated to Yahoo May close
-    commodities: { XAUT: 4524 }, // Gold was 4700
-    updatedAt: '2026-05-22T00:00:00Z',
+    // Weekly refresh 2026-06-26 (tools-data-weekly-runbook.md): risk-off leg
+    // vs the May stamp — BTC 77.3k→60k, gold 4524→4103, ETH/SOL down sharply.
+    // CoinGecko + Yahoo cross-checked; consistent with the firm-dollar /market read.
+    crypto: { BTC: 59986, ETH: 1577, SOL: 72, SUI: 0.7, TRX: 0.32 }, // 2026-06-26 spot (CoinGecko/Yahoo)
+    etfs: { SPYx: 729, QQQx: 707, IWMon: 234 }, // SPY/QQQ Yahoo 2026-06-26 close; IWM unchanged
+    commodities: { XAUT: 4103 }, // Tether Gold ≈ spot gold/oz, Yahoo GC=F 2026-06-26
+    updatedAt: '2026-06-26T00:00:00Z',
   },
   // FX rate unit-convention header (R2 — Phase 1 step 4 / FX-16 adoption 2026-05-26):
   //   • `annualDepreciation`         — decimal (0.0055 = 0.55%; negative = local currency strengthened)
@@ -96,31 +99,31 @@ export const FALLBACK_MARKET_DATA: MarketDataSnapshot = {
   exchangeRates: {
     rates: {
       BRL: {
-        rateToUsd: 5.0134,
+        rateToUsd: 5.1695,
         // Phase C (TOOLS_IMPROVEMENT.md, 2026-05-23, Decision PT1 ACCEPTED):
         // raised to live full-series CAGR per Phase A — 6.21%/yr USD/BRL
         // depreciation Jan 2010 → May 2026 (BCB PTAX). The Phase D
         // horizon-matched-CAGR helper recomputes from monthlySeries.fx[BRL]
         // at runtime; this constant is the data-unavailable fallback.
         annualDepreciation: 0.0621,
-        rateDate: '2026-05-22',
+        rateDate: '2026-06-26',
         depreciationBasis:
           'live full-series CAGR Jan 2010 → May 2026 (BCB PTAX); horizon-matched at runtime via monthlySeries.fx[BRL]',
         historicalCagr: 0.0621,
         historicalAnchorStart: '2010-01-01',
         historicalAnchorEnd: '2026-05-22',
         historicalRateStart: 1.874,
-        historicalRateEnd: 5.0134,
+        historicalRateEnd: 5.0134, // LOCKED anchor endpoint (do not refresh with spot)
       },
       EUR: {
-        rateToUsd: 0.8542,
+        rateToUsd: 0.8771,
         // FX-16 adoption D1 ACCEPTED 2026-05-26 (Bar): retired prior PT3 1.23% in
         // `annualDepreciation` — 1.23% was an endpoint-pair retrospective CAGR
         // mistakenly placed in the forward field. 1.23% remains in `historicalCagr`
         // (correct field) for the locked 2010→2026 anchor pair; 0.55% is the
         // forward calibration assumption. See `docs/audit/PENDING_ALL.md` D1.
         annualDepreciation: 0.0055,
-        rateDate: '2026-05-26',
+        rateDate: '2026-06-26',
         depreciationBasis:
           'Bar-signed forward calibration assumption (NOT a literal series CAGR). FRED AEXUSEU annual series 2010→2025 endpoint-pair CAGR is ~1.07%; 2005→2025 annual-average CAGR is ~0.48%. The 0.55% value is calibrated between those frames as a smoothed long-horizon projection assumption — see decision register D1 (2026-05-26) for the reasoning, and `docs/tech/audit-bundle/GLOSSARY_AND_LIMITATIONS.md` §"FX-16 forward calibration provenance" for the auditor-facing disclosure.',
         historicalCagr: 0.0123,


### PR DESCRIPTION
## What
Weekly **Money Tools** data refresh per `docs/tools/tools-data-weekly-runbook.md` (daily-ish cadence). Risk-off leg vs the May stamp — CoinGecko + Yahoo + BCB PTAX + ECB EXR cross-checked, and consistent with the firm-dollar `/market` regime read shipped in #357.

## Updated (`constants.ts`)
| Field | Old | New |
|---|---|---|
| BTC | 77,262 | 59,986 |
| ETH / SOL | 2,300 / 152 | 1,577 / 72 |
| SUI / TRX | 2.85 / 0.21 | 0.70 / 0.32 |
| SPYx / QQQx | 745 / 717 | 729 / 707 |
| XAUT (gold) | 4,524 | 4,103 |
| BRL→USD | 5.0134 | 5.1695 (PTAX 26/06) |
| EUR→USD | 0.8542 | 0.8771 (ECB, USD/EUR 1.1401) |

`updatedAt` → `2026-06-26`. **Bar-signed calibration fields** (`annualDepreciation`, `historicalCagr`, historical anchors) left untouched — only current-spot `rateToUsd`/`rateDate` changed. Guard tests in `formulas.test.ts` re-anchored.

## Deliberately NOT changed — flagged for follow-up
- **Selic** (`pt-BR.selicAnnualPct` 14.5): BCB SGS 432 returned **14.25** but with **anomalous future-dated rows (Aug 2026)** while every other feed shows 2026-06-26. A possible 25bp cut, but I won't change a user-facing poupança input on anomalous data — needs manual Copom-press-release verification.
- **Inflation** (`inflationRates.*.current`): US CPI YoY ticked to ~4.2% (FRED CPIAUCSL May), but a proper update needs NSA methodology + BR/DE/ES prints → monthly cadence.
- **Monthly series**: `monthlyPrices.json` May is the latest complete month (already present), June in progress → no append. `monthlyFx.json` May append deferred (monthly cadence).

These map to the substantive Track-2 sub-tasks (S&P TR-vs-price, EU card-fee, DAX/Ibovespa framing, DCA gates) which remain separate scoped items.

## Verification
- `tools-simulator.mjs` → pt-BR Retirement 25y FV **R$7,336,210** (≈ R$7.34M gate); **historical-FV outputs byte-identical** (spot-only change, no historical-math impact)
- type-check ✅ · web tests **1061/1061** ✅ · `validate:translations` (4-locale) ✅ · prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)