### PR TITLE
fix(copy): investor red-team live copy fixes 1-8 (CLO 022 cleared)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ flowchart TD
 - **i18n:** 33 namespaces × 4 locales, lazy-loaded per locale × namespace, drift-guarded by a parity test.
 - **Monitoring:** Sentry, PostHog, and GA4 — all consent-gated and lazy-loaded behind a cookie-consent check.
 
-> **Product architecture is Phase 2+, not in this build.** The money product's design — non-custodial by design (users hold their own funds; diBoaS cannot unilaterally move them), MPC wallets (Turnkey), Solana-first multi-chain — is roadmap. Those decisions live in [`CLAUDE.md`](./CLAUDE.md); the full technical write-up for reviewers belongs in the investor room's technical-architecture summary.
+> **Product architecture is Phase 2+, not in this build.** The money product's design — non-custodial by design (users hold their own funds; diBoaS holds no key shares, and recovery runs through an integrated third-party provider), MPC wallets (Turnkey), multi-chain DeFi (stable strategies on Arbitrum, growth on Solana) — is roadmap. Those decisions live in [`CLAUDE.md`](./CLAUDE.md); the full technical write-up for reviewers belongs in the investor room's technical-architecture summary.
 
 ## Prerequisites
 

--- a/packages/i18n/translations/de/faq.json
+++ b/packages/i18n/translations/de/faq.json
@@ -5,7 +5,7 @@
   "items": {
     "isBank": {
       "question": "Ist diBoaS eine Bank?",
-      "answer": "Nein.\n\ndiBoaS ist eine Finanz-App. Sie hilft dir, Geld einem Zweck zuzuordnen, mögliche Wege mit digitalen Dollar zu verstehen und vor einer Entscheidung klare Informationen zu sehen.\n\nDu verwahrst dein eigenes Geld. diBoaS ist die App, nicht der Verwahrer. diBoaS behält nur einen Teil-Wiederherstellungsschlüssel, nie die volle Kontrolle über dein Geld, und trifft keine finanziellen Entscheidungen für dich."
+      "answer": "Nein.\n\ndiBoaS ist eine Finanz-App. Sie hilft dir, Geld einem Zweck zuzuordnen, mögliche Wege mit digitalen Dollar zu verstehen und vor einer Entscheidung klare Informationen zu sehen.\n\nDein Geld gehört dir und bleibt bei dir. diBoaS ist die App, nicht der Verwahrer. diBoaS hält keinen Teil deines Schlüssels, keinen einzigen. Falls du deinen Zugang jemals wiederherstellen musst, läuft das über einen unabhängigen Partner für die Wiederherstellung, nicht über diBoaS. Niemand bei diBoaS kann dein Geld bewegen, und niemand hier trifft finanzielle Entscheidungen für dich."
     },
     "isForEveryone": {
       "question": "Ist diBoaS für jeden?",
@@ -29,7 +29,7 @@
     },
     "micaRegulated": {
       "question": "Ist diBoaS MiCA-reguliert?",
-      "answer": "diBoaS ist eine nicht-verwahrende Plattform. Gemäß der EU-Verordnung über Märkte für Kryptowerte (MiCA) fallen nicht-verwahrende Wallets nicht in den regulatorischen Geltungsbereich, da sie keine Kundengelder verwahren. Das bedeutet: Kein Kontoeinfrieren durch die Plattform. Dein Geld bleibt unter deiner Kontrolle. Siehe den vollständigen MiCA-Hinweis in unserer Fußzeile."
+      "answer": "diBoaS ist ohne Verwahrung gebaut: Es hält niemals dein Geld oder deine Schlüssel. Nach den EU-Kryptoregeln (MiCA) braucht eine Lizenz, wer Kundengelder verwahrt, und diBoaS ist so gebaut, dass es das nicht tut. Die Regeln entwickeln sich weiter, und wir verfolgen sie genau; diBoaS startet in jedem Markt erst, wenn der rechtliche Weg bestätigt ist. So oder so: Dein Geld bleibt unter deiner Kontrolle. Den vollständigen MiCA-Hinweis findest du in unserer Fußzeile."
     },
     "pixFaq": {
       "question": "Kann ich PIX bei diBoaS nutzen?",

--- a/packages/i18n/translations/de/legal/cookies.json
+++ b/packages/i18n/translations/de/legal/cookies.json
@@ -9,7 +9,7 @@
   "backToTop": "Nach oben",
   "header": {
     "title": "Cookie-Richtlinie",
-    "lastUpdated": "Zuletzt aktualisiert: 3. Januar 2026"
+    "lastUpdated": "Zuletzt aktualisiert: 5. Juli 2026"
   },
   "sections": {
     "whatAreCookies": {

--- a/packages/i18n/translations/de/legal/privacy.json
+++ b/packages/i18n/translations/de/legal/privacy.json
@@ -9,7 +9,7 @@
   "backToTop": "Nach oben",
   "header": {
     "title": "Datenschutzerklärung",
-    "lastUpdated": "Zuletzt aktualisiert: 3. Januar 2026",
+    "lastUpdated": "Zuletzt aktualisiert: 5. Juli 2026",
     "intro": "diBoaS (\"wir\", \"uns\", \"unser\") ist dem Schutz Ihrer Privatsphäre verpflichtet. Diese Richtlinie erklärt, wie wir Ihre personenbezogenen Daten erheben, verwenden und schützen."
   },
   "sections": {

--- a/packages/i18n/translations/de/legal/terms.json
+++ b/packages/i18n/translations/de/legal/terms.json
@@ -9,7 +9,7 @@
   "backToTop": "Nach oben",
   "header": {
     "title": "Nutzungsbedingungen",
-    "lastUpdated": "Zuletzt aktualisiert: 3. Januar 2026",
+    "lastUpdated": "Zuletzt aktualisiert: 5. Juli 2026",
     "intro": "Willkommen bei diBoaS. Durch den Zugriff auf unsere Website stimmen Sie diesen Nutzungsbedingungen zu."
   },
   "sections": {
@@ -29,7 +29,7 @@
       "intro": "Durch die Nutzung unserer Website bestätigen Sie:",
       "items": [
         "Sie sind mindestens 18 Jahre alt",
-        "Sie befinden sich nicht in einer eingeschränkten Gerichtsbarkeit (derzeit: Vereinigte Staaten, Brasilien)",
+        "Sie befinden sich nicht in einer Jurisdiktion, die internationalen Sanktionen unterliegt, oder in einer Jurisdiktion, in der diBoaS keinen Zugang anbietet (derzeit: China, Russland)",
         "Sie stimmen diesen Nutzungsbedingungen zu"
       ]
     },
@@ -54,7 +54,7 @@
     },
     "geographicRestrictions": {
       "title": "4. Geografische Verfügbarkeit",
-      "intro": "diBoaS befindet sich derzeit in der Pre-Launch-Phase. Wenn die Dienste verfügbar werden, werden sie zunächst Nutzern in den Vereinigten Staaten, der Europäischen Union und Brasilien angeboten. Die Verfügbarkeit in weiteren Regionen wird bekannt gegeben, sobald wir expandieren.",
+      "intro": "diBoaS befindet sich derzeit in der Pre-Launch-Phase. Wenn die Dienste verfügbar werden, werden sie zunächst Nutzern in den Vereinigten Staaten, der Europäischen Union und Brasilien angeboten. Die Verfügbarkeit in weiteren Regionen wird bekannt gegeben, sobald wir expandieren. Bestimmte Funktionen, etwa das Senden von Geld an andere Nutzer, werden Markt für Markt freigeschaltet, sobald die rechtlichen Anforderungen des jeweiligen Marktes bestätigt sind.",
       "note": "Während der Pre-Launch-Phase sind die Website und die Warteliste weltweit zugänglich. Bestimmte Funktionen oder Dienste können in Ländern eingeschränkt sein, in denen sie nach geltendem Recht nicht zulässig sind, einschließlich Länder, die internationalen Sanktionen unterliegen. Du bist dafür verantwortlich, sicherzustellen, dass deine Nutzung dieser Plattform mit den geltenden Gesetzen deines Landes vereinbar ist."
     },
     "intellectualProperty": {

--- a/packages/i18n/translations/de/security.json
+++ b/packages/i18n/translations/de/security.json
@@ -1,31 +1,31 @@
 {
   "seo": {
     "title": "Sicherheit | diBoaS",
-    "description": "So schützt diBoaS Ihr Geld. Ihre Wallet, Ihre Schlüssel. Nicht-verwahrende Architektur. Rund-um-die-Uhr-Überwachung.",
+    "description": "So schützt diBoaS dein Geld. Deine Wallet, deine Schlüssel. Nicht-verwahrende Architektur. Rund-um-die-Uhr-Überwachung.",
     "ogTitle": "Sicherheit | diBoaS",
-    "ogDescription": "Ihre Wallet, Ihre Schlüssel. Wie diBoaS Ihr Geld mit nicht-verwahrender Architektur und 24/7-Überwachung schützt."
+    "ogDescription": "Deine Wallet, deine Schlüssel. Wie diBoaS dein Geld mit nicht-verwahrender Architektur und 24/7-Überwachung schützt."
   },
   "hero": {
     "title": "Sicherheit",
-    "subtitle": "So schützen wir Ihr Geld."
+    "subtitle": "So schützen wir dein Geld."
   },
   "sections": {
     "wallet": {
-      "ariaLabel": "Ihre Wallet, Ihre Schlüssel",
-      "title": "Ihre Wallet, Ihre Schlüssel",
+      "ariaLabel": "Deine Wallet, deine Schlüssel",
+      "title": "Deine Wallet, deine Schlüssel",
       "paragraphs": [
         "Jeder Nutzer bekommt seine eigene Wallet mit seinem eigenen privaten Schlüssel.",
-        "diBoaS sieht, speichert oder hat niemals Zugang zu Ihrem Schlüssel.",
-        "Sollte diBoaS morgen verschwinden, wäre Ihr Geld immer noch Ihres."
+        "diBoaS sieht, speichert oder hat niemals Zugang zu deinem Schlüssel. Falls du deinen Zugang wiederherstellen musst, läuft das über einen unabhängigen Partner, niemals über diBoaS.",
+        "Sollte diBoaS morgen verschwinden, wäre dein Geld immer noch deins."
       ]
     },
     "protection": {
-      "ariaLabel": "Wie wir Ihr Geld schützen",
-      "title": "Wie wir Ihr Geld schützen",
+      "ariaLabel": "Wie wir dein Geld schützen",
+      "title": "Wie wir dein Geld schützen",
       "paragraphs": [
-        "Niemand, einschließlich diBoaS, kann auf Ihr Geld zugreifen.",
-        "Nur Sie können Transaktionen autorisieren.",
-        "Jede Transaktionssignierung erfordert Ihre Zustimmung.",
+        "Niemand, einschließlich diBoaS, kann auf dein Geld zugreifen.",
+        "Nur du kannst Transaktionen autorisieren.",
+        "Jede Transaktionssignierung erfordert deine Zustimmung.",
         "Wir überwachen alle Positionen rund um die Uhr."
       ]
     },
@@ -43,10 +43,10 @@
       "ariaLabel": "Was diBoaS nicht tut",
       "title": "Was wir nicht tun",
       "paragraphs": [
-        "Wir verwahren niemals Ihre privaten Schlüssel.",
-        "Wir führen niemals Transaktionen ohne Ihre Zustimmung durch.",
-        "Wir speichern Ihr Geld niemals auf unseren Servern.",
-        "Wir sind keine Bank und Ihr Geld ist nicht versichert."
+        "Wir verwahren niemals deine privaten Schlüssel.",
+        "Wir führen niemals Transaktionen ohne deine Zustimmung durch.",
+        "Wir speichern dein Geld niemals auf unseren Servern.",
+        "Wir sind keine Bank und dein Geld ist nicht versichert."
       ]
     },
     "transparency": {
@@ -63,10 +63,10 @@
   },
   "footer": {
     "general": "Dieser Inhalt dient ausschließlich zu Informationszwecken und stellt keine Anlage-, Finanz- oder sonstige Beratung dar.",
-    "crypto": "Der Wert von Krypto-Assets kann schwanken. Sie könnten einen Teil oder Ihr gesamtes Geld verlieren. Krypto-Assets sind nicht durch Einlagensicherungssysteme gedeckt.",
+    "crypto": "Der Wert von Krypto-Assets kann schwanken. Du könntest einen Teil oder dein gesamtes Geld verlieren. Krypto-Assets sind nicht durch Einlagensicherungssysteme gedeckt.",
     "mica": "",
     "micaArticle7": "Diese Krypto-Asset-Marketingmitteilung wurde von keiner zuständigen Behörde eines Mitgliedstaats der Europäischen Union geprüft oder genehmigt. Der Anbieter des Krypto-Assets ist allein für den Inhalt dieser Marketingmitteilung verantwortlich.",
-    "us": "diBoaS ist eine nicht-verwahrende Schnittstelle für dezentrale Finanzprotokolle. diBoaS ist nicht bei der SEC, CFTC, FinCEN oder einer staatlichen Regulierungsbehörde registriert. Die US-amerikanische regulatorische Behandlung von DeFi entwickelt sich weiter. Sie sind dafür verantwortlich festzustellen, ob Ihre Nutzung dieser Schnittstelle den geltenden Gesetzen entspricht.",
-    "closing": "Sie entscheiden, was für Ihre Situation am besten ist."
+    "us": "diBoaS ist eine nicht-verwahrende Schnittstelle für dezentrale Finanzprotokolle. diBoaS ist nicht bei der SEC, CFTC, FinCEN oder einer staatlichen Regulierungsbehörde registriert. Die US-amerikanische regulatorische Behandlung von DeFi entwickelt sich weiter. Du bist dafür verantwortlich festzustellen, ob deine Nutzung dieser Schnittstelle den geltenden Gesetzen entspricht.",
+    "closing": "Du entscheidest, was für deine Situation am besten ist."
   }
 }

--- a/packages/i18n/translations/de/strategies.json
+++ b/packages/i18n/translations/de/strategies.json
@@ -347,7 +347,7 @@
       }
     },
     "belowTable": "Sonst nichts. Keine versteckten Spreads oder Gebühren.\n\nGeld in eine Strategie zu stecken kostet nichts. Wir berechnen nur dann eine Gebühr, wenn du dein Geld herausnimmst. Wenn dein Geld in einer Strategie Rendite erwirtschaftet, verdienen wir nichts, bis du aussteigst.",
-    "microText": "Netzwerkgebühren Dritter können anfallen (in der Regel weniger als 0,01 EUR). Den vollständigen Gebührenkatalog einschließlich Überweisungen und Auszahlungen findest du auf unserer Gebührenseite."
+    "microText": "Netzwerkgebühren von Drittanbietern können anfallen (in der Regel unter 0,01 $). Die vollständige Kostenübersicht, einschließlich Überweisungen und Auszahlungen, findest du in der Kostentabelle auf unserer Startseite."
   },
   "howToChoose": {
     "header": "Fang hier an",
@@ -415,7 +415,7 @@
       "safe": {
         "question": "Ist mein Geld sicher?",
         "answerA": "Dein Geld wird von dir gesichert. Deine Wallet, deine Schlüssel. Niemand bei diBoaS kann ohne deine Genehmigung auf dein Guthaben zugreifen.\n\nAllerdings: Das ist kein Bankkonto. Dein Geld arbeitet in automatisierten Systemen, die auf Code basieren. Der Wert kann schwanken, und du kannst einen Teil oder dein gesamtes Investment verlieren. Es gibt keine Einlagensicherung.\n\nWir zeigen dir beide Seiten, die Chancen und die Risiken, immer.",
-        "answerB": "Dein Geld ist durch Multi-Party-Sicherheit geschützt. Deine Genehmigung ist für jede Transaktion erforderlich. DiBoaS hält einen teilweisen Schlüsselanteil für Wiederherstellungszwecke, kann dein Guthaben aber nicht einseitig bewegen.\n\nAllerdings: Das ist kein Bankkonto. Dein Geld arbeitet in automatisierten Systemen, die auf Code basieren. Der Wert kann schwanken, und du kannst einen Teil oder dein gesamtes Investment verlieren. Es gibt keine Einlagensicherung.\n\nWir zeigen dir beide Seiten, die Chancen und die Risiken, immer."
+        "answerB": "Dein Geld sicherst du selbst. Deine Wallet, deine Schlüssel, und diBoaS hält keinen Teil davon. Falls du den Zugang wiederherstellen musst, läuft das über einen unabhängigen Partner, nicht über diBoaS. Niemand bei diBoaS kann dein Geld bewegen.\n\nAllerdings: Das ist kein Bankkonto. Dein Geld arbeitet in automatisierten Systemen, die auf Code basieren. Der Wert kann schwanken, und du kannst einen Teil oder dein gesamtes Investment verlieren. Es gibt keine Einlagensicherung.\n\nWir zeigen dir beide Seiten, die Chancen und die Risiken, immer."
       },
       "loseEverything": {
         "question": "Kann ich alles verlieren?",

--- a/packages/i18n/translations/en/faq.json
+++ b/packages/i18n/translations/en/faq.json
@@ -5,7 +5,7 @@
   "items": {
     "isBank": {
       "question": "Is diBoaS a bank?",
-      "answer": "No.\n\ndiBoaS is a financial app. It helps you turn goals into digital-dollar paths, with clear information before you decide.\n\nYou hold your own money. diBoaS is the app, not the holder. diBoaS keeps only a partial recovery key, never full control of your funds, and does not make financial decisions for you."
+      "answer": "No.\n\ndiBoaS is a financial app. It helps you turn goals into digital-dollar paths, with clear information before you decide.\n\nYou hold your own money. diBoaS is the app, not the holder. diBoaS holds no part of your key, none. If you ever need to recover access, that runs through an independent recovery partner, not through diBoaS. No one at diBoaS can move your funds, and no one here makes financial decisions for you."
     },
     "isForEveryone": {
       "question": "Is diBoaS for everyone?",
@@ -29,7 +29,7 @@
     },
     "micaRegulated": {
       "question": "Is diBoaS MiCA-regulated?",
-      "answer": "diBoaS is a non-custodial platform. Under the EU Markets in Crypto-Assets Regulation (MiCA), non-custodial wallets fall outside the regulatory scope because they do not hold customer funds. This means: no account freezing by the platform. Your money stays under your control. See the full MiCA notice in our footer."
+      "answer": "diBoaS is built non-custodial: it never holds your money or your keys. Under the EU's crypto rules (MiCA), a license is required for services that hold customer funds, and diBoaS is designed not to hold them. The rules keep evolving, and we track them closely; diBoaS opens in each market only when its legal path is confirmed. Either way, your money stays under your control. See the full MiCA notice in our footer."
     },
     "pixFaq": {
       "question": "Can I use PIX with diBoaS?",
@@ -37,7 +37,7 @@
     },
     "whySaveDollar": {
       "question": "Why save in dollars instead of a savings account?",
-      "answer": "Because the real loses value every year against the dollar. Even when your savings account pays 7-8%, inflation and currency depreciation can eat most of that return. With diBoaS, your money is in digital dollars, protected against BRL depreciation. When you withdraw, you get more reais than you put in, not just from yield, but from the exchange rate working in your favor."
+      "answer": "Because the real has lost ground against the dollar in most years, and even when a savings account pays 7-8%, inflation and a weakening currency can quietly eat most of it. With diBoaS, your money sits in digital dollars. If the dollar strengthens against the real, the exchange rate works in your favor when you withdraw. If it moves the other way, it works against you. Two sides. We show you both before you decide."
     },
     "safety": {
       "question": "What are the risks?",

--- a/packages/i18n/translations/en/investor-docs.json
+++ b/packages/i18n/translations/en/investor-docs.json
@@ -434,7 +434,7 @@
         },
         {
           "type": "paragraph",
-          "text": "What's the fee schedule, exactly? Add money / cash out: 0.48%, capped at $250 for consumers and $2,500 for business. Close a strategy: 0.39%, capped at $25. Send, swap, bridge, starting a strategy, and receiving B2B payments: diBoaS fee $0 where supported. Network, ramp, provider, banking, exchange, or compliance-related costs may still apply and are passed through at cost — diBoaS never marks them up. The split cap is deliberate: the $25 cap protects someone cashing out their savings; the higher add/cash-out caps keep B2B economics intact. This schedule is the single source of truth (FEES.md) and is stated identically across every surface."
+          "text": "What's the fee schedule, exactly? Add money / cash out: 0.48%, capped at $250 for consumers and $2,500 for business. Close a strategy: 0.39%, capped at $25. Send, swap, bridge, starting a strategy, and receiving B2B payments: diBoaS fee $0 where supported. Network, ramp, provider, banking, exchange, or compliance-related costs may still apply and are passed through at cost — diBoaS never marks them up. The split cap is deliberate: the $25 cap protects someone cashing out their savings; the higher add/cash-out caps keep B2B economics intact. This schedule is the single source of truth (FEES.md) and is stated consistently on every surface, in each market's currency (consumer add/cash-out caps: $250 / €250 / R$250)."
         },
         {
           "type": "paragraph",

--- a/packages/i18n/translations/en/legal/cookies.json
+++ b/packages/i18n/translations/en/legal/cookies.json
@@ -9,7 +9,7 @@
   "backToTop": "Back to top",
   "header": {
     "title": "Cookie Policy",
-    "lastUpdated": "Last Updated: January 3, 2026"
+    "lastUpdated": "Last Updated: July 5, 2026"
   },
   "sections": {
     "whatAreCookies": {

--- a/packages/i18n/translations/en/legal/privacy.json
+++ b/packages/i18n/translations/en/legal/privacy.json
@@ -9,7 +9,7 @@
   "backToTop": "Back to top",
   "header": {
     "title": "Privacy Policy",
-    "lastUpdated": "Last Updated: January 3, 2026",
+    "lastUpdated": "Last Updated: July 5, 2026",
     "intro": "diBoaS (\"we,\" \"us,\" \"our\") is committed to protecting your privacy. This policy explains how we collect, use, and protect your personal data."
   },
   "sections": {

--- a/packages/i18n/translations/en/legal/terms.json
+++ b/packages/i18n/translations/en/legal/terms.json
@@ -9,7 +9,7 @@
   "backToTop": "Back to top",
   "header": {
     "title": "Terms of Use",
-    "lastUpdated": "Last Updated: January 3, 2026",
+    "lastUpdated": "Last Updated: July 5, 2026",
     "intro": "Welcome to diBoaS. By accessing our website, you agree to these Terms of Use."
   },
   "sections": {
@@ -29,7 +29,7 @@
       "intro": "By using our website, you confirm that:",
       "items": [
         "You are at least 18 years old",
-        "You are not located in a restricted jurisdiction (currently: United States, Brazil)",
+        "You are not located in a jurisdiction subject to international sanctions, or in a jurisdiction where diBoaS does not offer access (currently: China, Russia)",
         "You agree to these Terms of Use"
       ]
     },
@@ -54,7 +54,7 @@
     },
     "geographicRestrictions": {
       "title": "4. Geographic Availability",
-      "intro": "diBoaS is currently in pre-launch. When services become available, they will initially be offered to users in the United States, European Union, and Brazil. Availability in other regions will be announced as we expand.",
+      "intro": "diBoaS is currently in pre-launch. When services become available, they will initially be offered to users in the United States, European Union, and Brazil. Availability in other regions will be announced as we expand. Certain features, such as sending money to other users, are enabled market by market as the legal requirements of each market are confirmed.",
       "note": "During the pre-launch period, the website and waitlist are accessible worldwide. Certain features or services may be restricted in jurisdictions where they are not permitted under local law, including countries subject to international sanctions. You are responsible for determining whether your use of this interface complies with applicable laws in your jurisdiction."
     },
     "intellectualProperty": {

--- a/packages/i18n/translations/en/security.json
+++ b/packages/i18n/translations/en/security.json
@@ -15,7 +15,7 @@
       "title": "Your Wallet, Your Keys",
       "paragraphs": [
         "Every user gets their own wallet with their own private key.",
-        "diBoaS never sees, holds, or has access to your key.",
+        "diBoaS never sees, holds, or has access to your key. If you ever need to recover access, recovery runs through an independent partner, never through diBoaS.",
         "If diBoaS disappeared tomorrow, your money would still be yours."
       ]
     },

--- a/packages/i18n/translations/en/strategies.json
+++ b/packages/i18n/translations/en/strategies.json
@@ -347,7 +347,7 @@
       }
     },
     "belowTable": "Nothing else. No hidden spreads or charges.\n\nPutting money into a strategy costs nothing. We only charge when you take money out. If your money sits in a strategy earning returns, we earn nothing until you exit.",
-    "microText": "Third-party network fees may apply (typically less than $0.01). For the full fee schedule including transfers and cash-outs, see our fee page."
+    "microText": "Third-party network fees may apply (typically less than $0.01). For the full fee schedule including transfers and cash-outs, see the cost table on our home page."
   },
   "howToChoose": {
     "header": "Start here",
@@ -415,7 +415,7 @@
       "safe": {
         "question": "Is my money safe?",
         "answerA": "Your money is secured by you. Your wallet, your keys. No one at diBoaS can access your funds without your authorization.\n\nThat said, this isn't a bank account. Your funds work through automated systems built on code. The value can fluctuate, and you could lose some or all of your investment. There is no deposit insurance.\n\nWe show you both sides, the opportunities and the risks, always.",
-        "answerB": "Your money is protected by multi-party security. Your authorization is required for every transaction. DiBoaS holds a partial key share for recovery purposes, but cannot unilaterally move your funds.\n\nThat said, this isn't a bank account. Your funds work through automated systems built on code. The value can fluctuate, and you could lose some or all of your investment. There is no deposit insurance.\n\nWe show you both sides, the opportunities and the risks, always."
+        "answerB": "Your money is secured by you. Your wallet, your keys, and diBoaS holds no part of them. If you ever need to recover access, that runs through an independent partner, not diBoaS. No one at diBoaS can move your funds.\n\nThat said, this isn't a bank account. Your funds work through automated systems built on code. The value can fluctuate, and you could lose some or all of your investment. There is no deposit insurance.\n\nWe show you both sides, the opportunities and the risks, always."
       },
       "loseEverything": {
         "question": "Can I lose everything?",

--- a/packages/i18n/translations/es/faq.json
+++ b/packages/i18n/translations/es/faq.json
@@ -5,7 +5,7 @@
   "items": {
     "isBank": {
       "question": "¿Es diBoaS un banco?",
-      "answer": "No.\n\ndiBoaS es una app financiera. Te ayuda a asignar dinero a un objetivo, entender posibles caminos con dólares digitales y ver información clara antes de decidir.\n\nTú guardas tu propio dinero. diBoaS es la app, no la custodia, y solo conserva una clave parcial de recuperación, nunca el control total de tus fondos. No toma decisiones financieras por ti."
+      "answer": "No.\n\ndiBoaS es una app financiera. Te ayuda a asignar dinero a un objetivo, entender posibles caminos con dólares digitales y ver información clara antes de decidir.\n\nTu dinero es tuyo y se queda contigo. diBoaS es la aplicación, no el guardián. diBoaS no guarda ninguna parte de tu clave, ninguna. Si algún día necesitas recuperar el acceso, eso pasa por un socio independiente de recuperación, no por diBoaS. Nadie en diBoaS puede mover tu dinero, y nadie aquí toma decisiones financieras por ti."
     },
     "isForEveryone": {
       "question": "¿Es diBoaS para todo el mundo?",
@@ -29,7 +29,7 @@
     },
     "micaRegulated": {
       "question": "¿Es diBoaS compatible con MiCA?",
-      "answer": "diBoaS es una plataforma de custodia propia. Según el Reglamento europeo sobre los Mercados de Criptoactivos (MiCA), las carteras de custodia propia no entran en el ámbito regulatorio porque no custodian fondos de los usuarios. Esto significa: ningún bloqueo de cuenta por parte de la plataforma. Tu dinero permanece bajo tu control. Consulta el aviso MiCA completo en nuestro pie de página."
+      "answer": "diBoaS está construido sin custodia: nunca guarda tu dinero ni tus claves. Según las normas europeas de criptoactivos (MiCA), quien custodia fondos de clientes necesita una licencia, y diBoaS está diseñado para no custodiarlos. Las normas siguen evolucionando y las seguimos de cerca; diBoaS abre en cada mercado solo cuando su camino legal está confirmado. En cualquier caso, tu dinero queda bajo tu control. Consulta el aviso completo de MiCA en nuestro pie de página."
     },
     "pixFaq": {
       "question": "¿Puedo usar PIX con diBoaS?",

--- a/packages/i18n/translations/es/legal/cookies.json
+++ b/packages/i18n/translations/es/legal/cookies.json
@@ -9,7 +9,7 @@
   "backToTop": "Volver arriba",
   "header": {
     "title": "Política de Cookies",
-    "lastUpdated": "Última Actualización: 3 de enero de 2026"
+    "lastUpdated": "Última actualización: 5 de julio de 2026"
   },
   "sections": {
     "whatAreCookies": {

--- a/packages/i18n/translations/es/legal/privacy.json
+++ b/packages/i18n/translations/es/legal/privacy.json
@@ -9,7 +9,7 @@
   "backToTop": "Volver arriba",
   "header": {
     "title": "Política de Privacidad",
-    "lastUpdated": "Última Actualización: 3 de enero de 2026",
+    "lastUpdated": "Última actualización: 5 de julio de 2026",
     "intro": "diBoaS (\"nosotros\", \"nos\", \"nuestro\") está comprometido con la protección de tu privacidad. Esta política explica cómo recopilamos, usamos y protegemos tus datos personales."
   },
   "sections": {

--- a/packages/i18n/translations/es/legal/terms.json
+++ b/packages/i18n/translations/es/legal/terms.json
@@ -9,7 +9,7 @@
   "backToTop": "Volver arriba",
   "header": {
     "title": "Términos de Uso",
-    "lastUpdated": "Última Actualización: 3 de enero de 2026",
+    "lastUpdated": "Última actualización: 5 de julio de 2026",
     "intro": "Bienvenido a diBoaS. Al acceder a nuestro sitio web, aceptas estos Términos de Uso."
   },
   "sections": {
@@ -29,7 +29,7 @@
       "intro": "Al usar nuestro sitio web, confirmas que:",
       "items": [
         "Tienes al menos 18 años de edad",
-        "No te encuentras en una jurisdicción restringida (actualmente: Estados Unidos, Brasil)",
+        "No te encuentras en una jurisdicción sujeta a sanciones internacionales, ni en una jurisdicción donde diBoaS no ofrece acceso (actualmente: China, Rusia)",
         "Aceptas estos Términos de Uso"
       ]
     },
@@ -54,7 +54,7 @@
     },
     "geographicRestrictions": {
       "title": "4. Disponibilidad Geográfica",
-      "intro": "diBoaS se encuentra actualmente en fase de prelanzamiento. Cuando los servicios estén disponibles, se ofrecerán inicialmente a usuarios en Estados Unidos, la Unión Europea y Brasil. La disponibilidad en otras regiones se anunciará a medida que nos expandamos.",
+      "intro": "diBoaS se encuentra actualmente en fase de prelanzamiento. Cuando los servicios estén disponibles, se ofrecerán inicialmente a usuarios en Estados Unidos, la Unión Europea y Brasil. La disponibilidad en otras regiones se anunciará a medida que nos expandamos. Ciertas funciones, como enviar dinero a otros usuarios, se habilitan mercado por mercado, a medida que se confirman los requisitos legales de cada mercado.",
       "note": "Durante el período de prelanzamiento, el sitio web y la lista de espera son accesibles a nivel mundial. Ciertas funciones o servicios pueden estar restringidos en jurisdicciones donde no están permitidos por la legislación local, incluidos los países sujetos a sanciones internacionales. Eres responsable de determinar si tu uso de esta plataforma cumple con las leyes aplicables en tu jurisdicción."
     },
     "intellectualProperty": {

--- a/packages/i18n/translations/es/security.json
+++ b/packages/i18n/translations/es/security.json
@@ -15,7 +15,7 @@
       "title": "Tu Billetera, Tus Llaves",
       "paragraphs": [
         "Cada usuario tiene su propia billetera con su propia clave privada.",
-        "diBoaS nunca ve, guarda ni tiene acceso a tu clave.",
+        "diBoaS nunca ve, guarda ni tiene acceso a tu clave. Si necesitas recuperar el acceso, la recuperación pasa por un socio independiente, nunca por diBoaS.",
         "Si diBoaS desapareciera mañana, tu dinero seguiría siendo tuyo."
       ]
     },

--- a/packages/i18n/translations/es/strategies.json
+++ b/packages/i18n/translations/es/strategies.json
@@ -347,7 +347,7 @@
       }
     },
     "belowTable": "Nada más. Sin spreads ni cargos ocultos.\n\nMeter dinero en una estrategia no cuesta nada. Solo cobramos cuando sacas tu dinero. Si tu dinero está en una estrategia generando retornos, nosotros no ganamos nada hasta que salgas.",
-    "microText": "Pueden aplicarse comisiones de red de terceros (normalmente menos de 0,01 EUR). Para el cuadro completo de comisiones incluyendo transferencias y retiradas, consulta nuestra página de comisiones."
+    "microText": "Pueden aplicarse tarifas de red de terceros (normalmente menos de 0,01 $). Para la tabla completa de costes, incluidas transferencias y retiros, consulta la tabla de costes en nuestra página de inicio."
   },
   "howToChoose": {
     "header": "Empieza aquí",
@@ -415,7 +415,7 @@
       "safe": {
         "question": "¿Mi dinero está seguro?",
         "answerA": "Tu dinero está protegido por ti. Tu monedero, tus claves. Nadie en diBoaS puede acceder a tus fondos sin tu autorización.\n\nDicho esto, esto no es una cuenta bancaria. Tus fondos trabajan a través de sistemas automatizados construidos sobre código. El valor puede fluctuar, y podrías perder parte o toda tu inversión. No existe seguro de depósitos.\n\nTe mostramos las dos caras, las oportunidades y los riesgos, siempre.",
-        "answerB": "Tu dinero está protegido por seguridad multi-parte. Tu autorización es necesaria para cada transacción. DiBoaS posee una parte parcial de la clave con fines de recuperación, pero no puede mover tus fondos de forma unilateral.\n\nDicho esto, esto no es una cuenta bancaria. Tus fondos trabajan a través de sistemas automatizados construidos sobre código. El valor puede fluctuar, y podrías perder parte o toda tu inversión. No existe seguro de depósitos.\n\nTe mostramos las dos caras, las oportunidades y los riesgos, siempre."
+        "answerB": "Tu dinero lo proteges tú. Tu billetera, tus claves, y diBoaS no guarda ninguna parte de ellas. Si necesitas recuperar el acceso, eso pasa por un socio independiente, no por diBoaS. Nadie en diBoaS puede mover tu dinero.\n\nDicho esto, esto no es una cuenta bancaria. Tus fondos trabajan a través de sistemas automatizados construidos sobre código. El valor puede fluctuar, y podrías perder parte o toda tu inversión. No existe seguro de depósitos.\n\nTe mostramos las dos caras, las oportunidades y los riesgos, siempre."
       },
       "loseEverything": {
         "question": "¿Puedo perderlo todo?",

--- a/packages/i18n/translations/pt-BR/faq.json
+++ b/packages/i18n/translations/pt-BR/faq.json
@@ -5,7 +5,7 @@
   "items": {
     "isBank": {
       "question": "O diBoaS é um banco?",
-      "answer": "Não.\n\nO diBoaS é um app financeiro. Ele ajuda você a transformar objetivos em caminhos em dólar digital, com informação clara antes de decidir.\n\nVocê guarda o seu próprio dinheiro. A diBoaS é o app, não a guardiã, e mantém apenas uma chave parcial de recuperação, nunca o controle total dos seus fundos, e não toma decisões financeiras por você."
+      "answer": "Não.\n\nO diBoaS é um app financeiro. Ele ajuda você a transformar objetivos em caminhos em dólar digital, com informação clara antes de decidir.\n\nO dinheiro é seu e fica com você. O diBoaS é o aplicativo, não o cofre. O diBoaS não guarda nenhuma parte da sua chave, nenhuma. Se um dia você precisar recuperar o acesso, isso acontece por um parceiro independente de recuperação, não pelo diBoaS. Ninguém no diBoaS consegue mover o seu dinheiro, e ninguém aqui toma decisões financeiras por você."
     },
     "isForEveryone": {
       "question": "O diBoaS é pra todo mundo?",
@@ -29,7 +29,7 @@
     },
     "micaRegulated": {
       "question": "O diBoaS é regulamentado pela MiCA?",
-      "answer": "A MiCA é uma regulamentação da União Europeia. O diBoaS é uma plataforma não-custodial. Carteiras não-custodiais estão fora do escopo regulatório da MiCA porque não custodiam fundos de clientes."
+      "answer": "O diBoaS foi construído sem custódia: ele nunca guarda o seu dinheiro nem as suas chaves. Pelas regras europeias de criptoativos (MiCA), quem guarda fundos de clientes precisa de licença, e o diBoaS foi desenhado para não guardar. As regras continuam evoluindo, e a gente acompanha de perto; o diBoaS só abre em cada mercado quando o caminho legal está confirmado. De todo jeito, o seu dinheiro fica sob o seu controle."
     },
     "pixFaq": {
       "question": "Posso usar PIX no diBoaS?",

--- a/packages/i18n/translations/pt-BR/investor-docs.json
+++ b/packages/i18n/translations/pt-BR/investor-docs.json
@@ -542,7 +542,7 @@
         },
         {
           "type": "paragraph",
-          "text": "Esta tabela é a fonte única de verdade (FEES.md) e está idêntica em todas as superfícies."
+          "text": "Esta tabela é a fonte única de verdade (FEES.md) e é informada de forma consistente em todas as superfícies, na moeda de cada mercado (limites de add/cash-out para consumidores: US$ 250 / € 250 / R$ 250)."
         },
         {
           "type": "paragraph",

--- a/packages/i18n/translations/pt-BR/legal/cookies.json
+++ b/packages/i18n/translations/pt-BR/legal/cookies.json
@@ -9,7 +9,7 @@
   "backToTop": "Voltar ao topo",
   "header": {
     "title": "Politica de Cookies",
-    "lastUpdated": "Ultima Atualizacao: 3 de Janeiro de 2026"
+    "lastUpdated": "Última atualização: 5 de julho de 2026"
   },
   "sections": {
     "whatAreCookies": {

--- a/packages/i18n/translations/pt-BR/legal/privacy.json
+++ b/packages/i18n/translations/pt-BR/legal/privacy.json
@@ -9,7 +9,7 @@
   "backToTop": "Voltar ao topo",
   "header": {
     "title": "Politica de Privacidade",
-    "lastUpdated": "Ultima Atualizacao: 3 de Janeiro de 2026",
+    "lastUpdated": "Última atualização: 5 de julho de 2026",
     "intro": "O diBoaS (\"nos\", \"nosso\", \"nossa\") esta comprometido em proteger sua privacidade. Esta politica explica como coletamos, utilizamos e protegemos seus dados pessoais."
   },
   "sections": {

--- a/packages/i18n/translations/pt-BR/legal/terms.json
+++ b/packages/i18n/translations/pt-BR/legal/terms.json
@@ -9,7 +9,7 @@
   "backToTop": "Voltar ao topo",
   "header": {
     "title": "Termos de Uso",
-    "lastUpdated": "Ultima Atualizacao: 3 de Janeiro de 2026",
+    "lastUpdated": "Última atualização: 5 de julho de 2026",
     "intro": "Bem-vindo ao diBoaS. Ao acessar nosso site, você concorda com estes Termos de Uso."
   },
   "sections": {
@@ -29,7 +29,7 @@
       "intro": "Ao utilizar nosso site, você confirma que:",
       "items": [
         "Você tem pelo menos 18 anos de idade",
-        "Você não esta localizado em uma jurisdicao restrita (atualmente: Estados Unidos, Brasil)",
+        "Você não está localizado em uma jurisdição sujeita a sanções internacionais, nem em uma jurisdição onde o diBoaS não oferece acesso (atualmente: China, Rússia)",
         "Você concorda com estes Termos de Uso"
       ]
     },
@@ -54,7 +54,7 @@
     },
     "geographicRestrictions": {
       "title": "4. Disponibilidade Geográfica",
-      "intro": "O diBoaS está atualmente em fase de pré-lançamento. Quando os serviços estiverem disponíveis, serão oferecidos inicialmente para usuários nos Estados Unidos, União Europeia e Brasil. A disponibilidade em outras regiões será anunciada conforme expandirmos.",
+      "intro": "O diBoaS está atualmente em fase de pré-lançamento. Quando os serviços estiverem disponíveis, serão oferecidos inicialmente para usuários nos Estados Unidos, União Europeia e Brasil. A disponibilidade em outras regiões será anunciada conforme expandirmos. Alguns recursos, como enviar dinheiro para outros usuários, são habilitados mercado a mercado, conforme os requisitos legais de cada mercado forem confirmados.",
       "note": "Durante o período de pré-lançamento, o site e a lista de espera estão acessíveis mundialmente. Certas funcionalidades ou serviços podem ser restritos em jurisdições onde não são permitidos pela legislação local, incluindo países sujeitos a sanções internacionais. Você é responsável por determinar se o uso desta plataforma está em conformidade com as leis aplicáveis na sua jurisdição."
     },
     "intellectualProperty": {

--- a/packages/i18n/translations/pt-BR/security.json
+++ b/packages/i18n/translations/pt-BR/security.json
@@ -15,7 +15,7 @@
       "title": "Sua Carteira, Suas Chaves",
       "paragraphs": [
         "Cada usuário tem sua própria carteira com sua própria chave privada.",
-        "O diBoaS nunca vê, armazena ou tem acesso à sua chave.",
+        "O diBoaS nunca vê, armazena ou tem acesso à sua chave. Se você precisar recuperar o acesso, a recuperação acontece por um parceiro independente, nunca pelo diBoaS.",
         "Se o diBoaS desaparecesse amanhã, seu dinheiro ainda seria seu."
       ]
     },

--- a/packages/i18n/translations/pt-BR/strategies.json
+++ b/packages/i18n/translations/pt-BR/strategies.json
@@ -347,7 +347,7 @@
       }
     },
     "belowTable": "Nada mais. Sem spreads ou cobranças ocultas.\n\nColocar dinheiro em uma estratégia não custa nada. Nós só cobramos quando você resgata. Se seu dinheiro está em uma estratégia rendendo, nós não ganhamos nada até você sair.",
-    "microText": "Taxas de rede de terceiros podem se aplicar (normalmente menos de R$0,05). Para a tabela completa de taxas incluindo transferências e saques, veja nossa página de taxas."
+    "microText": "Taxas de rede de terceiros podem se aplicar (normalmente menos de US$ 0,01). Para a tabela completa de custos, incluindo transferências e saques, veja a tabela de custos na nossa página inicial."
   },
   "howToChoose": {
     "header": "Comece aqui",
@@ -415,7 +415,7 @@
       "safe": {
         "question": "Meu dinheiro está seguro?",
         "answerA": "Seu dinheiro é protegido por você. Sua carteira, suas chaves. Ninguém no diBoaS pode acessar seus fundos sem sua autorização.\n\nDito isso, isso não é uma conta bancária. Seus fundos trabalham através de sistemas automatizados construídos em código. O valor pode oscilar, e você pode perder parte ou todo o seu dinheiro. Não existe seguro de depósito.\n\nNós mostramos os dois lados, as oportunidades e os riscos, sempre.",
-        "answerB": "Seu dinheiro é protegido por segurança multi-parte. Sua autorização é necessária pra cada transação. O diBoaS detém uma parcela parcial da chave pra fins de recuperação, mas não pode mover seus fundos unilateralmente.\n\nDito isso, isso não é uma conta bancária. Seus fundos trabalham através de sistemas automatizados construídos em código. O valor pode oscilar, e você pode perder parte ou todo o seu dinheiro. Não existe seguro de depósito.\n\nNós mostramos os dois lados, as oportunidades e os riscos, sempre."
+        "answerB": "Seu dinheiro é protegido por você. Sua carteira, suas chaves, e o diBoaS não guarda nenhuma parte delas. Se precisar recuperar o acesso, isso acontece por um parceiro independente, não pelo diBoaS. Ninguém no diBoaS consegue mover o seu dinheiro.\n\nDito isso, isso não é uma conta bancária. Seus fundos trabalham através de sistemas automatizados construídos em código. O valor pode oscilar, e você pode perder parte ou todo o seu dinheiro. Não existe seguro de depósito.\n\nNós mostramos os dois lados, as oportunidades e os riscos, sempre."
       },
       "loseEverything": {
         "question": "Posso perder tudo?",


### PR DESCRIPTION
## Summary

Applies the founder-approved copy fixes from the investor red-team review (`docs/audit/INVESTOR_RED_TEAM_2026-07-05.md`, decisions F-1…F-12), executed per `docs/audit/CC_COPY_FIX_PLAN_2026-07-05.md`. **CLO Session 022 ratified the custody P1-3 reversal and signed off Fixes 2/3/4; merge gate lifted (022-6).** Per founder decision 2026-07-06, the demo-flow addendum items (S1–S3/S8) are deprioritized to backlog and are NOT in this PR (`docs/audit/CC_COPY_FIX_ADDENDUM_2026-07-06.md`).

| Fix | What | Locales |
|---|---|---|
| 1 (CRITICAL) | Custody single truth: "diBoaS holds no part of your key" + independent recovery partner (home/help FAQ, /security, strategies answerB, README) — replaces "partial recovery key / partial key share" | ×4 |
| 2 (CRITICAL) | EN help FX answer: promised outcome → conditional both-directions | en |
| 3 (HIGH) | Terms: eligibility → sanctions + China/Russia (was US/Brazil self-contradiction); availability + D-004 "market by market" send sentence | ×4 |
| 4 (HIGH) | MiCA help answer: categorical "outside the scope" → governed position (pt-BR drops footer pointer — CVM footer, CLO 022-4 accepted) | ×4 |
| 5 (MED) | Investor FAQ "stated identically" → "stated consistently … in each market's currency" (EN + pt-BR regenerated) | en, pt-BR |
| 6a/6c (MED) | Legal Last-Updated → July 5, 2026; strategies "see our fee page" → home cost table | ×4 |
| 7 (MED) | DE /security Sie → du | de |
| 8 (LOW) | README/INTRO multi-chain truth (stable on Arbitrum, growth on Solana) | docs |

## Verification

- Gates: format:check · translations parity (33×4) · type-check · lint · **1089/1089 tests** · build 7/7 — all green.
- Post-edit greps: zero survivors of "partial recovery key/key share" (any locale), "more reais than you put in", "United States, Brazil" restriction, "outside the regulatory scope" family.
- Live dev verification (fresh server): custody + MiCA + FX answers render on /en/help (screenshots attached in session); /en/security recovery line; /en/strategies answerB + fee repoint (note: page renders answerA unless `NEXT_PUBLIC_WALLET_ARCHITECTURE=mpc`; both variants now compliant); terms eligibility/availability/date stamps verified in all 4 locales; DE du-form (0 Sie survivors); pt-BR MiCA without footer pointer.
- 375px: no horizontal overflow on DE terms.

## Notes for reviewer

- **Accepted residual:** de/es `investor-docs.json` still carry the pre-Fix-5 "stated identically" line — those files are never rendered (`roomContentLocale` serves EN to DE/ES) and are regenerated wholesale by the figures-registry workstream (R3). Deliberately not regenerated here to keep this PR reviewable.
- `/api/consent` 403 seen during LAN visual testing is the CSRF origin allowlist rejecting the LAN IP — pre-existing dev-environment artifact, unrelated.
- `docs/tech/DATA_VINTAGE_POLICY.md` (untracked Track-B artifact) deliberately excluded.
- Docker MCP browser died mid-pass; coverage completed via rendered-DOM checks + fresh-server HTML verification. A follow-up visual sweep runs at the end of the registry workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)