### PR TITLE
fix(ci): market-refresh — POLYGON_API_KEY at job level so the ETF snapshot step runs

### DIFF
--- a/.github/workflows/market-refresh-weekly.yml
+++ b/.github/workflows/market-refresh-weekly.yml
@@ -27,6 +27,12 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Map the secret to env at the JOB level so `env.POLYGON_API_KEY` is
+    # reliably visible to every step's `if:` guard (step-level env is NOT
+    # dependable in that same step's own `if` condition — the ETF leg would
+    # otherwise skip even when the secret is set).
+    env:
+      POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
     steps:
       - uses: actions/checkout@v6
 
@@ -45,13 +51,9 @@ jobs:
 
       - name: ETF-01 weekly snapshot (optional leg)
         if: ${{ env.POLYGON_API_KEY != '' }}
-        env:
-          POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
         run: node apps/web/scripts/market-refresh/run.mjs --etf-snapshot --no-archive || true
 
       - name: Refresh pipeline (fetch → gate → compute → archive)
-        env:
-          POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
         run: node apps/web/scripts/market-refresh/run.mjs --append-btc
 
       - name: Tools monthlies (F-M8 leg — idempotent, appends only at month-roll)


### PR DESCRIPTION
One-line CI fix uncovered while setting the `POLYGON_API_KEY` repo secret.

The weekly market-refresh workflow's ETF-01 snapshot step guarded on `if: env.POLYGON_API_KEY != ''` but only mapped the secret to env *inside that same step* — step-level env isn't dependable in the step's own `if`, so the step could skip even with the secret set. That would leave the ETF flow ledger stuck at 1 snapshot and ETF-01 permanently UNAVAILABLE.

Fix: map the secret at the **job** level so `env.POLYGON_API_KEY` is reliably visible to the guard and every step; removed the redundant per-step env blocks.

Pure workflow change — no app or runtime code. The scheduled run is Mondays 06:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)