### PR TITLE
docs: self-audit corrections (accurate test count + ETF-01 residual)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,7 +390,7 @@ Landed 2026-07-11 (one continuous session, five stacked merges + one follow-up):
 - **Supply-chain hardening (pnpm 8.15 → 10.33)** — dependency lifecycle scripts blocked by default + curated `onlyBuiltDependencies` allowlist, 3-day `minimumReleaseAge` registry-hijack guard, quarterly security-scan workflow. Record: `docs/audit/SUPPLY_CHAIN_SPRINT_2026-07-11.md`.
 - **Health endpoint fix** — serverless-correct status semantics (heap% is telemetry, not a health input; DB-down = 503, redis-down = degraded 200) — stopped prod 503-flapping.
 
-Prior context (still true): Tools audit-bundle externally validated to v1.8; the 2026-05-26 architecture challenge and Track A backlog (A0–A17) closed; the investor workstream (figures registry, F22 room-gate fix, A3 numbers layer) shipped 2026-07-06; the messaging/locale sweep (D-MSG-1…10, `docs/audit/MESSAGING_FIX_PLAN_2026-07-07.md`) audited end-to-end. **~1,207 tests passing.**
+Prior context (still true): Tools audit-bundle externally validated to v1.8; the 2026-05-26 architecture challenge and Track A backlog (A0–A17) closed; the investor workstream (figures registry, F22 room-gate fix, A3 numbers layer) shipped 2026-07-06; the messaging/locale sweep (D-MSG-1…10, `docs/audit/MESSAGING_FIX_PLAN_2026-07-07.md`) audited end-to-end. **~1,212 tests passing.**
 
 - Full audit narrative + test-count progression: **`docs/audit/AUDIT_HISTORY.md`**
 - Live security findings ledger: `docs/audit/SECURITY_FINDINGS_2026-05.md`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ flowchart TD
 
 ### Engineering posture (built — verifiable in this repo)
 
-- **Testing & CI:** strict TypeScript, ~1,207 automated tests (Vitest), Lighthouse CI + pa11y (WCAG 2.1 AA), and 6 GitHub Actions workflows (CI, security audit, accessibility, E2E, Lighthouse, quarterly security scan) plus a weekly /market data-refresh workflow.
+- **Testing & CI:** strict TypeScript, ~1,212 automated tests (Vitest), Lighthouse CI + pa11y (WCAG 2.1 AA), and 6 GitHub Actions workflows (CI, security audit, accessibility, E2E, Lighthouse, quarterly security scan) plus a weekly /market data-refresh workflow.
 - **Security:** per-request **nonce-based CSP** (`'unsafe-inline'` prohibited for scripts), **AES-256-GCM** encryption for PII at rest, **HMAC blind indexing**, Upstash rate limiting, DOMPurify sanitization, and CSRF protection on mutation endpoints.
 - **i18n:** 34 namespaces × 4 locales, lazy-loaded per locale × namespace, drift-guarded by a parity test.
 - **Monitoring:** Sentry, PostHog, and GA4 — all consent-gated and lazy-loaded behind a cookie-consent check.

--- a/docs/integrations/market-editorial.md
+++ b/docs/integrations/market-editorial.md
@@ -288,5 +288,5 @@ If you're unsure whether a change is editorial or engineering, default to engine
 - i18n locale list + naming conventions: `docs/tech/internationalization.md`
 - ETF-01 net-flow sourcing + source fetchability / headless-browser policy: `docs/researches/MoneyTools_LiveData_Consolidated.md` §4.5
 - canonical-vs-live drift log (signal-taxonomy + score-band decisions, D1/D2): `docs/mvp/integration/13_host_integration_guides/diboas_platform.md` §23
-- reproducible compute helper (strict-Friday weekly resampling locked, §5.1 candle-lock for BTC monthlies, evaluates 10 of 11 signals — ETF-01 manual per §8.3): `apps/web/scripts/data-fetchers/compute-regime.mjs`
+- reproducible compute helper (strict-Friday weekly resampling locked, §5.1 candle-lock for BTC monthlies, evaluates all 11 signals — ETF-01 now auto-derived from the Polygon shares-outstanding ledger, P4): `apps/web/scripts/data-fetchers/compute-regime.mjs`
 - standing pre-launch carry-forwards (chart strategy, Farside acquisition, LBMA replacement): `docs/audit/PENDING_ALL.md` items 5.27 / 5.28 / 5.29


### PR DESCRIPTION
Follow-up audit of the doc refresh. Fixes: test count ~1,207→~1,212 (verified: suite runs 1,212), and one residual "ETF-01 manual / 10 of 11 signals" line in market-editorial that contradicted the shipped Polygon automation. All other doc claims re-verified accurate against ground truth (11 tools, 34 namespaces incl. legal/*, pnpm 10.33.2, turbo 2.10.4, Next.js 16.2.6, money-jobs.md constants exact). No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)