### PR TITLE
fix(ci): wire validate:ux-canon + check:ux-greps into CI (they were never real gates)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,17 @@ jobs:
       # absent. The registry↔artifact consistency is ALSO covered by `pnpm test`
       # (figures-consistency.test.ts); this makes the script gate explicit too.
       - run: pnpm validate:investor-figures
+      # UX governance drift guard (2026-07-12): makes the governance layer a
+      # REAL merge gate, not just a local check. `validate:ux-canon` was in
+      # `validate:all` but never mirrored here when the other static gates were
+      # pulled out (C-3), so it had never actually run in CI — the whole canon /
+      # checklist / VOICE_RUBRIC drift guard was inert. CI-safe: it existsSync-
+      # guards the untracked areas (docs/full-view/, docs/audit/) and passes on
+      # the tracked-only tree (verified via `git archive HEAD`). `check:ux-greps`
+      # is the machine-tell gate (emoji hard-fail; em-dash/hardcoded-English are
+      # advisory, non-failing) — also previously manual-only.
+      - run: pnpm validate:ux-canon
+      - run: pnpm check:ux-greps
       - run: pnpm build
       # Phase 5.2 (audit/2026-05-09): Turbopack-aware bundle-budget gate.
       # Replaces the original webpack-plugin enforcement (was inert under


### PR DESCRIPTION
**The governance layer's mechanical gates were not actually enforced.** `validate:ux-canon` lived in `validate:all` but was never added to the discrete CI steps when the other static validators were pulled out (C-3) — so the whole canon / checklist / VOICE_RUBRIC drift guard had never once run in CI. A PR could break canon-ID contiguity, veto-list parity, a citation, a dead link, or the "N enforcement files" count and CI would stay green. `check:ux-greps` (the machine-tell gate — emoji hard-fail) was in neither `validate:all` nor CI: manual-only.

Both are now discrete CI steps. Verified CI-safe: `validate:ux-canon` existsSync-guards the untracked areas (`docs/full-view/`, `docs/audit/`) and passes on the tracked-only tree (checked via `git archive HEAD`); both exit 0 on the current tree.

**Scope:** mechanical gates only. The voice rubric (Q1–Q4) and the Part-3 friction/veto self-check stay judgment gates enforced by CLAUDE.md build rules + the design-reviewer agent — a validator cannot score voice by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
