### PR TITLE
fix(learn): approved Talk 1 content + Phase 0 bug fixes

### DIFF
--- a/apps/web/src/app/[locale]/(landing)/learn/compound-interest/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/learn/compound-interest/page.tsx
@@ -48,10 +48,12 @@ export default async function CompoundInterestLessonPage({ params }: LocalePageP
     pageMessages['learn.lessons.compoundInterest.cardDescription'] ??
     "The math the banks have been using for centuries. Now it's your turn.";
 
+  // B-3 (learn redesign plan, 2026-07-15): breadcrumb names localized via the
+  // learn namespace (wires the previously-dead `learn.nav.label`, F-8).
   const breadcrumbData = SEOMetadataFactory.generateBreadcrumbs(
     [
-      { name: 'Home', url: '/' },
-      { name: 'Learn', url: '/learn' },
+      { name: pageMessages['learn.nav.home'] ?? 'Home', url: '/' },
+      { name: pageMessages['learn.nav.label'] ?? 'Learn', url: '/learn' },
       { name: lessonTitle, url: '/learn/compound-interest' },
     ],
     locale

--- a/apps/web/src/app/[locale]/(landing)/learn/page.tsx
+++ b/apps/web/src/app/[locale]/(landing)/learn/page.tsx
@@ -36,10 +36,13 @@ export default async function LearnIndexPage({ params }: LocalePageProps) {
   // shared MinimalFooter's `landing-b2c.footer.*` keys resolve.
   const pageMessages = await loadPageNamespaces(locale, ['learn', 'landing-b2c']);
 
+  // B-3 (learn redesign plan, 2026-07-15): breadcrumb names are localized via
+  // the learn namespace (this also wires the previously-dead `learn.nav.label`
+  // key, gate-audit F-8). Fallbacks keep the JSON-LD valid if a key is absent.
   const breadcrumbData = SEOMetadataFactory.generateBreadcrumbs(
     [
-      { name: 'Home', url: '/' },
-      { name: 'Learn', url: '/learn' },
+      { name: pageMessages['learn.nav.home'] ?? 'Home', url: '/' },
+      { name: pageMessages['learn.nav.label'] ?? 'Learn', url: '/learn' },
     ],
     locale
   );

--- a/apps/web/src/components/Sections/CompoundInterestCalculator/variants/CalculatorDefault/CalculatorVignettes.tsx
+++ b/apps/web/src/components/Sections/CompoundInterestCalculator/variants/CalculatorDefault/CalculatorVignettes.tsx
@@ -21,9 +21,10 @@ interface VignetteRow {
  * rates — never hardcoded. This eliminates the arithmetic-vs-geometric
  * monthly-rate drift documented in Phase-7 audit L3.
  *
- * The lesson stays NON-HEDGED per Q7(a) / R2 — non-USD locales see raw
- * Historical 10% (NOT effective-rate APY). The tools' real-world numbers
- * differ from the lesson's; that's intentional pedagogical design.
+ * The vignettes use the CONSERVATIVE 7% scenario (Option A, founder
+ * 2026-07-14), matching the reworked Talk 1 copy that labels them a careful
+ * 7% recurring estimate. The calculator below still shows 7/10/14. The lesson
+ * stays NON-HEDGED (NOT effective-rate APY); real-tool numbers may differ.
  *
  * Each vignette row in translations must have `yearlyAmount` (number) — the
  * machine-readable annual contribution that feeds the engine. The
@@ -42,14 +43,14 @@ export function CalculatorVignettes() {
     }),
   };
 
-  const historicalDecimal = SCENARIO_RATES.historical / 100;
+  const conservativeDecimal = SCENARIO_RATES.conservative / 100;
 
   const rows: VignetteRow[] = [0, 1, 2].map((i) => {
     const yearlyAmount = Number(
       intl.formatMessage({ id: `learn-compound-interest.beat2.vignettes.${i}.yearlyAmount` })
     );
     const monthly = yearlyAmount / 12;
-    const fv = calculateMonthlyContributions(monthly, historicalDecimal, 0, 144).nominalFV;
+    const fv = calculateMonthlyContributions(monthly, conservativeDecimal, 0, 144).nominalFV;
     return {
       habit: intl.formatMessage({ id: `learn-compound-interest.beat2.vignettes.${i}.habit` }),
       yearly: intl.formatMessage({ id: `learn-compound-interest.beat2.vignettes.${i}.yearly` }),

--- a/apps/web/src/components/Sections/Lesson/variants/LessonThreeBeat/LessonThreeBeat.tsx
+++ b/apps/web/src/components/Sections/Lesson/variants/LessonThreeBeat/LessonThreeBeat.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from '@diboas/i18n/client';
 import { isValidLocale, type SupportedLocale } from '@diboas/i18n/config';
 import { analyticsService } from '@/lib/analytics';
 import {
+  BEAT_PARAGRAPH_COUNTS,
   LESSON_EVENTS,
   READ_TIME_MINUTES,
   type LessonId,
@@ -102,11 +103,50 @@ export function LessonThreeBeat({
     });
   };
 
-  const beat1Body = tArray('beat1.body', 7);
-  const beat2Intro = tArray('beat2.intro', 4);
-  const beat2Outro = tArray('beat2.outro', 3);
-  const beat3Intro = tArray('beat3.intro', 5);
-  const beat3Wrap = tArray('beat3.wrap', 2);
+  // B-4a: the lesson -> tool funnel edge (was untracked).
+  const handleToolDeepLink = () => {
+    if (!enableAnalytics) return;
+    analyticsService.track({
+      name: LESSON_EVENTS.TOOL_DEEPLINK_CLICKED,
+      parameters: { lessonId, locale, tool: 'compound-interest', timestamp: Date.now() },
+    });
+  };
+
+  // B-4b: LESSON_COMPLETED fires when the end-of-content CTA group becomes
+  // >=50% visible, once per mount (the KPI definition in lib/learn/constants).
+  const ctaGroupRef = useRef<HTMLDivElement | null>(null);
+  const completedRef = useRef(false);
+  useEffect(() => {
+    if (!enableAnalytics) return;
+    const el = ctaGroupRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting || completedRef.current) continue;
+          completedRef.current = true;
+          analyticsService.track({
+            name: LESSON_EVENTS.LESSON_COMPLETED,
+            parameters: { lessonId, locale, timestamp: Date.now() },
+          });
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.5 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [enableAnalytics, lessonId, locale]);
+
+  // Counts come from the shared contract in lib/learn/constants.ts; drift
+  // against the translation JSONs is caught by lessonCopyShape.test.ts.
+  const beat1Body = tArray('beat1.body', BEAT_PARAGRAPH_COUNTS.beat1Body);
+  const beat2Intro = tArray('beat2.intro', BEAT_PARAGRAPH_COUNTS.beat2Intro);
+  const beat2Outro = tArray('beat2.outro', BEAT_PARAGRAPH_COUNTS.beat2Outro);
+  const beat3Intro = tArray('beat3.intro', BEAT_PARAGRAPH_COUNTS.beat3Intro);
+  const beat3Wrap = tArray('beat3.wrap', BEAT_PARAGRAPH_COUNTS.beat3Wrap);
 
   const beatLabels = [t('beat1.title'), t('beat2.title'), t('beat3.title')];
 
@@ -202,6 +242,7 @@ export function LessonThreeBeat({
                       key="tool-deep-link"
                       href="/tools/compound-interest"
                       prefetch={false}
+                      onClick={handleToolDeepLink}
                     >
                       {chunks}
                     </LocaleLink>
@@ -216,7 +257,7 @@ export function LessonThreeBeat({
               </p>
             ))}
 
-            <div className={styles.ctaGroup}>
+            <div className={styles.ctaGroup} ref={ctaGroupRef}>
               <CTAButtonLink href={primaryCtaHref} variant="primary" onClick={handlePrimaryCta}>
                 {t('beat3.cta.primary')}
               </CTAButtonLink>

--- a/apps/web/src/components/Sections/LessonRoadmap/RoadmapCard.tsx
+++ b/apps/web/src/components/Sections/LessonRoadmap/RoadmapCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { KeyboardEvent } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from '@diboas/i18n/client';
 import { analyticsService } from '@/lib/analytics';
 import { LESSON_EVENTS, type RoadmapLessonKey } from '@/lib/learn';
@@ -11,6 +11,17 @@ interface RoadmapCardProps {
   enableAnalytics?: boolean;
 }
 
+/**
+ * Coming-soon roadmap card.
+ *
+ * Phase 0 a11y fix (B-2, learn redesign plan 2026-07-15): the card previously
+ * carried role="button" + tabIndex + key handling (added by visual-audit F-L2
+ * for keyboard parity with an onClick), but activating it did nothing
+ * user-visible, so screen readers announced a button that was a no-op. The
+ * card is informational: all interactive semantics AND the click handler are
+ * removed, and the honest signal is an impression (>=50% visible, once per
+ * mount) via the same IntersectionObserver pattern as LessonProgressBar.
+ */
 export function RoadmapCard({ lessonKey, enableAnalytics = true }: RoadmapCardProps) {
   const intl = useTranslation();
 
@@ -22,36 +33,40 @@ export function RoadmapCard({ lessonKey, enableAnalytics = true }: RoadmapCardPr
   });
   const comingSoonLabel = intl.formatMessage({ id: 'learn.roadmap.comingSoon' });
 
-  const handleClick = () => {
-    if (!enableAnalytics) return;
-    analyticsService.track({
-      name: LESSON_EVENTS.ROADMAP_CARD_CLICKED,
-      parameters: {
-        lessonKey,
-        locale: intl.locale,
-        timestamp: Date.now(),
-      },
-    });
-  };
+  const cardRef = useRef<HTMLElement | null>(null);
+  const viewedRef = useRef(false);
+  const locale = intl.locale;
 
-  // Keyboard parity for the click handler (visual-audit F-L2): the card carried an
-  // onClick with no role/keyboard, so keyboard + screen-reader users couldn't reach it.
-  const handleKeyDown = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleClick();
-    }
-  };
+  useEffect(() => {
+    if (!enableAnalytics) return;
+    const el = cardRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting || viewedRef.current) continue;
+          viewedRef.current = true;
+          analyticsService.track({
+            name: LESSON_EVENTS.ROADMAP_CARD_VIEWED,
+            parameters: {
+              lessonKey,
+              locale,
+              timestamp: Date.now(),
+            },
+          });
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.5 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [enableAnalytics, lessonKey, locale]);
 
   return (
-    <article
-      className={styles.card}
-      data-status="comingSoon"
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
-    >
+    <article className={styles.card} data-status="comingSoon" ref={cardRef}>
       <span className={styles.badge}>{comingSoonLabel}</span>
       <h3 className={styles.cardTitle}>{title}</h3>
       <p className={styles.cardDescription}>{description}</p>

--- a/apps/web/src/lib/learn/__tests__/lessonCopyShape.test.ts
+++ b/apps/web/src/lib/learn/__tests__/lessonCopyShape.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copy-shape drift guard (Phase 0 of the learn redesign plan, 2026-07-15).
+ *
+ * LessonThreeBeat reads translation arrays with FIXED lengths from
+ * BEAT_PARAGRAPH_COUNTS. If a copy update changes a paragraph count in the
+ * JSON without updating the constant, the page renders raw translation keys
+ * (count too high) or silently drops approved paragraphs (count too low).
+ * That exact bug shipped with the 2026-07-15 Talk 1 rework (7/4/3/5/2 vs the
+ * new 6/3/2/4/3) and was caught in review; this test makes it impossible to
+ * repeat. The Phase-1 config-driven variant will retire both the constant and
+ * this guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { BEAT_PARAGRAPH_COUNTS } from '../constants';
+
+const LOCALES = ['en', 'pt-BR', 'es', 'de'] as const;
+
+/** Walk up from this test to the repo root and locate the translations dir. */
+function findTranslationsDir(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(dir, 'packages/i18n/translations');
+    if (existsSync(candidate)) return candidate;
+    dir = dirname(dir);
+  }
+  throw new Error('Could not locate packages/i18n/translations');
+}
+
+interface LessonNamespace {
+  beat1: { body: string[] };
+  beat2: { intro: string[]; outro: string[] };
+  beat3: { intro: string[]; wrap: string[] };
+}
+
+describe('learn-compound-interest copy shape matches BEAT_PARAGRAPH_COUNTS', () => {
+  const translationsDir = findTranslationsDir();
+
+  it.each([...LOCALES])('locale "%s" array lengths match the component contract', (locale) => {
+    const raw = readFileSync(
+      join(translationsDir, locale, 'learn-compound-interest.json'),
+      'utf-8'
+    );
+    const json = JSON.parse(raw) as LessonNamespace;
+
+    expect(json.beat1.body).toHaveLength(BEAT_PARAGRAPH_COUNTS.beat1Body);
+    expect(json.beat2.intro).toHaveLength(BEAT_PARAGRAPH_COUNTS.beat2Intro);
+    expect(json.beat2.outro).toHaveLength(BEAT_PARAGRAPH_COUNTS.beat2Outro);
+    expect(json.beat3.intro).toHaveLength(BEAT_PARAGRAPH_COUNTS.beat3Intro);
+    expect(json.beat3.wrap).toHaveLength(BEAT_PARAGRAPH_COUNTS.beat3Wrap);
+  });
+});

--- a/apps/web/src/lib/learn/__tests__/registryInvariants.test.ts
+++ b/apps/web/src/lib/learn/__tests__/registryInvariants.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Registry invariants (Phase 0 of the learn redesign plan, 2026-07-15).
+ *
+ * Adding a lesson currently requires keeping several hand-maintained maps in
+ * sync (the technical audit's "registry facade" finding). Until the Phase-1
+ * refactor collapses them, this test makes every sync point fail loudly:
+ *  - READ_TIME_MINUTES has an entry per lesson
+ *  - the lesson's i18n namespace is registered in SUPPORTED_NAMESPACES
+ *  - the lesson's route has a PAGE_SEO_CONFIG entry (drives sitemap + metadata)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SUPPORTED_NAMESPACES } from '@diboas/i18n/config';
+import { LESSONS, getActiveLessons } from '../registry';
+import { READ_TIME_MINUTES } from '../constants';
+import { PAGE_SEO_CONFIG } from '@/lib/seo/constants';
+
+describe('lesson registry invariants', () => {
+  const lessons = Object.values(LESSONS);
+
+  it('should register at least one lesson and expose active ones', () => {
+    expect(lessons.length).toBeGreaterThan(0);
+    expect(getActiveLessons().length).toBeGreaterThan(0);
+  });
+
+  it.each(lessons.map((l) => [l.id, l] as const))(
+    'lesson "%s" has all hand-maintained sync points',
+    (_id, lesson) => {
+      // Read time
+      expect(
+        READ_TIME_MINUTES[lesson.id],
+        `READ_TIME_MINUTES missing "${lesson.id}"`
+      ).toBeGreaterThan(0);
+
+      // i18n namespace registered (drift-guarded against the file set elsewhere)
+      expect(
+        (SUPPORTED_NAMESPACES as readonly string[]).includes(lesson.namespace),
+        `SUPPORTED_NAMESPACES missing "${lesson.namespace}"`
+      ).toBe(true);
+
+      // SEO config drives the sitemap; without it the lesson never gets indexed
+      const seoKey = `learn/${lesson.slug}`;
+      expect(
+        Object.prototype.hasOwnProperty.call(PAGE_SEO_CONFIG, seoKey),
+        `PAGE_SEO_CONFIG missing "${seoKey}" (sitemap + metadata)`
+      ).toBe(true);
+    }
+  );
+});

--- a/apps/web/src/lib/learn/__tests__/structuredData.test.ts
+++ b/apps/web/src/lib/learn/__tests__/structuredData.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the Learn Center structured data (JSON-LD).
+ *
+ * Phase 0 of the learn redesign plan (B-1): the live lesson page emitted
+ * `"timeRequired": "PT[object Object]M"` because the whole READ_TIME_MINUTES
+ * record was interpolated instead of the lesson's value. These tests lock the
+ * fix and the schema shape so future lessons can't regress it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/seo', () => ({
+  seoService: {
+    generateCanonicalUrl: (path: string, locale: string) => `https://diboas.com/${locale}${path}`,
+  },
+}));
+
+import { buildLessonStructuredData, buildLearnIndexStructuredData } from '../structuredData';
+import { READ_TIME_MINUTES } from '../constants';
+import { getActiveLessons } from '../registry';
+
+describe('buildLessonStructuredData', () => {
+  it('should emit a valid ISO-8601 timeRequired for the lesson (B-1 regression)', () => {
+    const data = buildLessonStructuredData({
+      lessonId: 'compound-interest',
+      locale: 'en',
+      title: 'How Money Really Grows',
+      description: 'Test description',
+    });
+
+    expect(data).not.toBeNull();
+    expect(data!.timeRequired).toBe(`PT${READ_TIME_MINUTES['compound-interest']}M`);
+    // The exact bug: interpolating the record produced "[object Object]".
+    expect(String(data!.timeRequired)).not.toContain('[object Object]');
+    expect(String(data!.timeRequired)).toMatch(/^PT\d+M$/);
+  });
+
+  it('should emit a LearningResource with locale-aware URL and caller-provided copy', () => {
+    const data = buildLessonStructuredData({
+      lessonId: 'compound-interest',
+      locale: 'pt-BR',
+      title: 'Como o Dinheiro Realmente Cresce',
+      description: 'Descrição',
+    });
+
+    expect(data!['@type']).toBe('LearningResource');
+    expect(data!.url).toBe('https://diboas.com/pt-BR/learn/compound-interest');
+    expect(data!.inLanguage).toBe('pt-BR');
+    expect(data!.name).toBe('Como o Dinheiro Realmente Cresce');
+    expect(data!.isAccessibleForFree).toBe(true);
+  });
+
+  it('should have a timeRequired entry for every registered lesson', () => {
+    for (const lesson of getActiveLessons()) {
+      expect(
+        READ_TIME_MINUTES[lesson.id],
+        `READ_TIME_MINUTES missing entry for lesson "${lesson.id}"`
+      ).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('buildLearnIndexStructuredData', () => {
+  it('should emit an ItemList with one positioned entry per active lesson', () => {
+    const data = buildLearnIndexStructuredData({
+      locale: 'en',
+      lessonTitles: { 'compound-interest': 'How Money Really Grows' },
+    });
+
+    expect(data).not.toBeNull();
+    expect(data!['@type']).toBe('ItemList');
+    expect(data!.itemListElement).toHaveLength(getActiveLessons().length);
+    expect(data!.itemListElement[0]).toMatchObject({
+      '@type': 'ListItem',
+      position: 1,
+      name: 'How Money Really Grows',
+    });
+  });
+});

--- a/apps/web/src/lib/learn/constants.ts
+++ b/apps/web/src/lib/learn/constants.ts
@@ -4,6 +4,15 @@
  * Naming follows the existing platform pattern: snake_case, feature-prefixed.
  * Event payloads always include locale + timestamp per the analytics
  * integration guide (docs/tech/analytics-integration.md).
+ *
+ * Phase 0 (learn redesign plan, 2026-07-15):
+ * - ROADMAP_CARD_CLICKED replaced by ROADMAP_CARD_VIEWED: the coming-soon card
+ *   is informational (no navigation), so the honest signal is an impression,
+ *   not a click on a fake button (a11y fix B-2).
+ * - TOOL_DEEPLINK_CLICKED added: the lesson -> tool edge of the funnel (B-4).
+ * - LESSON_COMPLETED now fires (B-4). KPI definition: the lesson counts as
+ *   completed when the end-of-content CTA group becomes >=50% visible, once
+ *   per mount. Dashboards depend on this definition staying stable.
  */
 
 export const LESSON_EVENTS = {
@@ -11,13 +20,33 @@ export const LESSON_EVENTS = {
   LESSON_VIEWED: 'learn_lesson_viewed',
   BEAT_VIEWED: 'learn_beat_viewed',
   LESSON_COMPLETED: 'learn_lesson_completed',
-  ROADMAP_CARD_CLICKED: 'learn_roadmap_card_clicked',
+  ROADMAP_CARD_VIEWED: 'learn_roadmap_card_viewed',
   CTA_PRIMARY_CLICKED: 'learn_cta_primary_clicked',
   CTA_SECONDARY_CLICKED: 'learn_cta_secondary_clicked',
+  TOOL_DEEPLINK_CLICKED: 'learn_tool_deeplink_clicked',
 } as const;
 
 export type LessonEventName = (typeof LESSON_EVENTS)[keyof typeof LESSON_EVENTS];
 
 export const READ_TIME_MINUTES = {
   'compound-interest': 5,
+} as const;
+
+/**
+ * Paragraph counts per beat for the `learn-compound-interest` namespace.
+ *
+ * TEMPORARY CONTRACT (until the Phase-1 config-driven variant): the
+ * LessonThreeBeat component reads translation arrays with fixed lengths, so
+ * these counts MUST match the actual array lengths in
+ * `packages/i18n/translations/{locale}/learn-compound-interest.json` for all
+ * four locales. Drift is caught by `__tests__/lessonCopyShape.test.ts`.
+ *
+ * Updated 2026-07-15 for the approved Talk 1 rework (was 7/4/3/5/2).
+ */
+export const BEAT_PARAGRAPH_COUNTS = {
+  beat1Body: 6,
+  beat2Intro: 3,
+  beat2Outro: 2,
+  beat3Intro: 4,
+  beat3Wrap: 3,
 } as const;

--- a/apps/web/src/lib/learn/index.ts
+++ b/apps/web/src/lib/learn/index.ts
@@ -7,6 +7,11 @@ export type {
   VideoSourceConfig,
 } from './types';
 export { LESSONS, ROADMAP, getLesson, getActiveLessons } from './registry';
-export { LESSON_EVENTS, READ_TIME_MINUTES, type LessonEventName } from './constants';
+export {
+  LESSON_EVENTS,
+  READ_TIME_MINUTES,
+  BEAT_PARAGRAPH_COUNTS,
+  type LessonEventName,
+} from './constants';
 export { generateLessonMetadata, generateLearnIndexMetadata } from './lessonMetadata';
 export { buildLessonStructuredData, buildLearnIndexStructuredData } from './structuredData';

--- a/apps/web/src/lib/learn/structuredData.ts
+++ b/apps/web/src/lib/learn/structuredData.ts
@@ -47,7 +47,7 @@ export function buildLessonStructuredData(args: {
     learningResourceType: 'Lesson',
     educationalLevel: 'beginner',
     teaches: 'Personal finance: how compound interest works',
-    timeRequired: `PT${READ_TIME_MINUTES}M`,
+    timeRequired: `PT${READ_TIME_MINUTES[lesson.id]}M`,
     isAccessibleForFree: true,
     audience: {
       '@type': 'EducationalAudience',

--- a/packages/i18n/translations/de/learn-compound-interest.json
+++ b/packages/i18n/translations/de/learn-compound-interest.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "Wie Geld wirklich wächst — Zinseszins erklärt",
+    "title": "Wie Geld wirklich wächst: Zinseszins erklärt",
     "description": "Verstehe, wie Zinseszins funktioniert: die Mathematik, die Banken und die Wall Street seit Jahrzehnten nutzen. Gib deine eigenen Zahlen ein und sieh, wie 12 Jahre aussehen."
   },
   "lesson": {
@@ -8,77 +8,74 @@
     "readTime": "~5 Min Lesezeit",
     "lastUpdated": {
       "label": "Zuletzt aktualisiert:",
-      "date": "Mai 2026"
+      "date": "Juli 2026"
     }
   },
   "beat1": {
     "title": "Sparen ist nur die halbe Wahrheit.",
     "body": [
-      "Schwierig. Notwendig. Der erste Schritt. Aber für sich genommen verändert es dein Leben nicht.",
-      "1.000 € gespart sind 1.000 € — in sechs Monaten. In einem Jahr. In vierzig Jahren.",
-      "Dieselben 1.000 € könnten aber **~2.252 € in 12 Jahren** sein.",
-      "Wie?",
-      "Indem du machst, was jede Bank und jeder Wall-Street-Fonds seit Jahrhunderten macht. Zinseszins.",
-      "Die Banken wissen das. Die Fonds wissen das. Sie nutzen es seit Jahrzehnten mit deinem Geld — und zahlen dir fast nichts dafür zurück.",
-      "Jetzt bist du dran."
+      "Leg vor einem Jahr 1.000 € aufs Sparkonto, und heute sind sie ungefähr… 1.003 € wert. Das ist das ganze Problem, und es ist nicht deine Schuld. Dir hat nie jemand die andere Hälfte gezeigt.",
+      "1.000 € gespart sind 1.000 €. In sechs Monaten. In einem Jahr. In vierzig Jahren.",
+      "Dieselben 1.000 € könnten aber, **selbst zu vorsichtigen 7 %,** in 12 Jahren zu ungefähr **2.252 €** werden. Du hast keinen Cent dazugelegt. Der Zuwachs hat angefangen, seinen eigenen Zuwachs zu verdienen.",
+      "Das ist Zinseszins, die Mathematik, die jede Bank und jeder Wall-Street-Fonds seit Jahrhunderten nutzt.",
+      "Er liegt in keinem Tresor. Es hat sich nur nie jemand hingesetzt und ihn dir erklärt. (Meine Oma hat jahrzehntelang alles richtig gemacht, und ihr hat das nie jemand gezeigt.)",
+      "Er ist die stärkste Kraft im ganzen Thema Geld, und fast niemand außerhalb dieser Welt nutzt sie wirklich. In den nächsten Talks geht es um das *Warum*. In diesem hier geht es darum, *wie er funktioniert*."
     ]
   },
   "beat2": {
-    "title": "Der unsichtbare Motor des Systems.",
+    "title": "Du brauchst kein Vermögen, um anzufangen.",
     "intro": [
-      "Du denkst vielleicht — *woher soll ich denn das Geld zum Investieren nehmen?*",
-      "Keine Sorge. Wir kommen dir nicht mit der alten 50/30/20-Regel. Die hat funktioniert, als Mieten noch bezahlbar waren, als die Inflation unter Kontrolle war, als der Wocheneinkauf nicht ein halbes Vermögen gekostet hat.",
-      "Diese Welt ist vorbei. Wir leben in dieser hier.",
-      "Reden wir also über etwas Einfacheres. Kleine Dinge, für die du Geld ausgibst, ohne darüber nachzudenken."
+      "Du denkst dir vielleicht: *Wo soll ich denn das Geld zum Investieren hernehmen?*",
+      "Verständlich. Und wir halten dir keinen Vortrag über die alte 50/30/20-Regel. Die hat mit Mieten, Wocheneinkäufen und einer Inflation gerechnet, die es so nicht mehr gibt. Diese Welt ist vorbei. Wir leben in dieser.",
+      "Also vergiss Regeln. Denk an die kleinen Dinge, für die du sowieso schon Geld ausgibst, ohne nachzudenken."
     ],
-    "habitsLine": "Dein Bäckerei-Frühstück morgens. Das Restaurant am Wochenende. Streaming und Fitnessstudio jeden Monat.",
-    "vignettesIntro": "Wenn nur eines davon für dich arbeiten würde, statt einfach wegzufließen, beim gleichen historischen Zinssatz von 10 %, dann sehen 12 Jahre so aus:",
+    "habitsLine": "Dein Kaffee unterwegs. Der Lieferdienst am Freitag. Deine Streaming-Abos jeden Monat.",
+    "vignettesIntro": "Die 1.000 € waren einmalig, so wie das Weihnachtsgeld. Gewohnheiten sind anders: sie *wiederholen* sich. Stell dir also vor, du lenkst eine kleine Gewohnheit um, Monat für Monat, 12 Jahre lang. Ein Kaffee für 3 € an Werktagen sind rund 60 € im Monat. Zum selben vorsichtigen Zinssatz von 7 % investiert, könnte jede einzelne davon hier landen:",
     "vignettes": [
       {
-        "habit": "Bäckerei-Frühstück (4 €/Tag werktags)",
-        "yearly": "1.040 €",
-        "yearlyAmount": "1040"
+        "habit": "Kaffee unterwegs (3 €/Tag an Werktagen)",
+        "yearly": "720 €",
+        "yearlyAmount": "720"
       },
       {
-        "habit": "Restaurant am Wochenende (35 €/Woche)",
-        "yearly": "1.820 €",
-        "yearlyAmount": "1820"
+        "habit": "Lieferdienst am Freitag (30 €/Woche)",
+        "yearly": "1.560 €",
+        "yearlyAmount": "1560"
       },
       {
-        "habit": "Streaming + Fitnessstudio (40 €/Monat)",
-        "yearly": "480 €",
-        "yearlyAmount": "480"
+        "habit": "Streaming-Abos (20 €/Monat)",
+        "yearly": "240 €",
+        "yearlyAmount": "240"
       }
     ],
     "vignettesTableHeaders": {
       "habit": "Gewohnheit",
       "yearly": "Pro Jahr",
-      "twelveYear": "Könnte in 12 Jahren werden"
+      "twelveYear": "Könnte in 12 Jahren werden (Schätzung)"
     },
     "vignettesOutro": "Dasselbe Geld. Andere Aufgabe.",
-    "vignettesDisclaimer": "Illustrative Zahlen auf Basis eines historischen Zinssatzes von 10 %. Vergangene Wertentwicklungen garantieren keine zukünftigen Ergebnisse.",
-    "habitsRecap": "Niemand verlangt von dir, das Frühstück zu streichen. Oder das Restaurant. Oder das Streaming. Behalte, was dein Leben besser macht.",
+    "vignettesDisclaimer": "Illustrative Zahlen. Sie unterstellen, dass diese Gewohnheit in gleichen monatlichen Beträgen investiert wird, Monat für Monat, 12 Jahre lang, zu vorsichtigen 7 % Zinseszins. Die historischen 10 % und optimistische 14 % findest du im Rechner unten. Szenarien, keine Versprechen. Vergangene Wertentwicklung ist keine Garantie für die Zukunft.",
+    "habitsRecap": "Niemand verlangt von dir, deinen Kaffee, deinen Lieferdienst oder dein Streaming aufzugeben. Behalte, was dein Leben gut macht.",
     "outro": [
-      "Aber wenn nur eines davon — nur eines — für dich arbeiten würde, statt jeden Monat zu verschwinden, dann passiert genau die Mathematik, die du oben gesehen hast.",
-      "Genau das machen die Banken. Mit deinem Geld. Seit Jahrzehnten.",
-      "Jetzt bist du dran."
+      "Aber wenn nur eine davon, nur eine einzige, für dich arbeiten würde, statt jeden Monat zu verschwinden, dann ist das genau die Mathematik, die du gerade gesehen hast.",
+      "Die Banken machen das seit Jahrzehnten. Adelaide hat es nie jemand gezeigt. Jetzt hast du es gesehen."
     ]
   },
   "beat3": {
-    "title": "Jetzt benutze es selbst.",
+    "title": "Jetzt nimm deine eigenen Zahlen.",
     "intro": [
-      "Die Rechnung oben war mit Bäckerei, Restaurant und Streaming. Das sind Beispiele. Dein Leben ist deins.",
-      "Setz also deine eigenen Zahlen ein.",
-      "Wofür gibst du täglich, wöchentlich oder monatlich Geld aus, das du nicht wirklich vermissen würdest, wenn es stattdessen für dich arbeiten würde?",
-      "Das wöchentliche Essengehen. Die Abos, die sich angesammelt haben. Die paar Euro, die jeden Tag auf dem Weg zur Arbeit verschwinden. Was auch immer es ist — gib es unten ein.",
-      "Die Grafik zeigt dir, wie 12 Jahre aussehen. Bei drei verschiedenen Zinssätzen. Verglichen mit dem, was deine Bank dir gerade zahlt."
+      "Das waren meine Beispiele: ein Kaffee, ein Lieferdienst, ein paar Abos. Dein Leben ist deins.",
+      "Und hier der ehrliche Teil: Ich stehe hinter diBoaS, ich habe also einen Grund, zu wollen, dass dich das hier begeistert. Glaub mir deshalb kein Wort.",
+      "Setz unten deine eigenen Zahlen ein, das, was du wirklich ausgibst und nicht wirklich vermissen würdest. Wähl deine Jahre. Die Grafik zeigt, was passiert, bei drei verschiedenen Zinssätzen, direkt neben dem, was deine Bank dir gerade zahlt.",
+      "Lass deine eigene Rechnung sprechen. Das ist die einzige Zahl, die zählt."
     ],
     "calculatorTagline": "Dasselbe Geld. Andere Aufgabe.",
     "afterCalculator": "Zahlen verstanden?",
     "toolDeepLink": "Willst du diesen Rechner allein? <link>Zum eigenständigen Zinseszins-Rechner</link>",
     "wrap": [
-      "Genau dafür ist diBoaS da. Der Teil deines Geldes, den du zur Seite legen kannst, der zu einem Zinssatz arbeitet, den sich das System bisher selbst behalten hat.",
-      "Deine Bank bleibt, wo sie ist — für Ausgaben, Rechnungen und den Alltag. diBoaS ist für Geld mit einem Ziel."
+      "Das ist Zinseszins. Du hast gerade die eine Idee verstanden, auf der das ganze Finanzsystem läuft, und du kannst sie jetzt in deinen eigenen Zahlen sehen.",
+      "Genau für diesen Teil deines Geldes ist diBoaS da: den Teil, den du zur Seite legen kannst, mit einem Ziel, der zu einem Zinssatz arbeitet, den sich das System bisher meist selbst behalten hat. Deine Bank bleibt, wo sie ist, für Ausgaben, Rechnungen und den Alltag.",
+      "Aber da ist ein Haken, und das ist Talk 2: Zinseszins funktioniert nur bei Geld, das irgendwo hin kann. Das meiste Geld bekommt diese Chance nie. Es versickert vorher. Als Nächstes schauen wir uns an, warum."
     ],
     "cta": {
       "primary": "Auf die Warteliste",
@@ -113,6 +110,6 @@
     "tableHeaderRate": "Jahreszins",
     "tableHeaderTotal": "Nach {years} Jahren",
     "loadingState": "Wird berechnet…",
-    "calibrationNote": "Was die Raten bedeuten. Die 7% konservativ sind das stabilere Szenario, die 10% historisch liegen in der Mitte des langfristigen Bereichs, und die 14% optimistisch sind das aktivere Szenario. Das sind Szenarien, keine Versprechen, und jede Rate trägt Risiko. Unabhängig davon: der S&P 500 erzielte langfristig im Schnitt rund 10% Gesamtrendite pro Jahr (nominal, mit reinvestierten Dividenden; rund 7% nach Inflation), Gold rund 7% pro Jahr. Langfristig schnitt Sparen in brasilianischen Real schlechter ab als das Halten des Digital-Dollar (vollständige Zahlen in unseren Recherchenotizen)."
+    "calibrationNote": "Was die Zinssätze bedeuten. Die vorsichtigen 7 % sind das stabilere Szenario, die historischen 10 % liegen langfristig in der Mitte, die optimistischen 14 % sind das bewegtere. Das sind Szenarien, keine Versprechen, und jede Rate trägt Risiko. Zur Einordnung: Der S&P 500 erzielte langfristig im Schnitt rund 10 % pro Jahr (nominal, mit reinvestierten Dividenden; rund 7 % nach Inflation), Gold rund 7 % pro Jahr. Deine Bank zahlt seit Jahren nahe null, während die Inflation dein Erspartes still auffrisst (vollständige Zahlen in unseren Recherche-Notizen)."
   }
 }

--- a/packages/i18n/translations/de/learn.json
+++ b/packages/i18n/translations/de/learn.json
@@ -4,7 +4,8 @@
     "description": "Kurze, ehrliche Lektionen über das Finanzsystem, geschrieben für die Menschen, für die das System nicht gemacht wurde."
   },
   "nav": {
-    "label": "Lernen"
+    "label": "Lernen",
+    "home": "Startseite"
   },
   "index": {
     "h1": "Lerne, wie Geld wirklich funktioniert.",

--- a/packages/i18n/translations/en/learn-compound-interest.json
+++ b/packages/i18n/translations/en/learn-compound-interest.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "How Money Really Grows — Compound Interest Explained",
+    "title": "How Money Really Grows: Compound Interest Explained",
     "description": "Learn how compound interest works: the math banks and Wall Street have used for decades. Plug in your own numbers and see what 12 years looks like."
   },
   "lesson": {
@@ -8,31 +8,29 @@
     "readTime": "~5 min read",
     "lastUpdated": {
       "label": "Last updated:",
-      "date": "May 2026"
+      "date": "July 2026"
     }
   },
   "beat1": {
-    "title": "Saving is half of the story.",
+    "title": "Saving is only half the story.",
     "body": [
-      "Difficult. Necessary. The first step. But on its own, never life-changing.",
-      "$1,000 saved is $1,000 in six months. In one year. In forty years.",
-      "But that same $1,000 could grow to about **$2,252 in 12 years.**",
-      "How?",
-      "Doing what every bank and every Wall Street firm has been doing for centuries. Using compound interest.",
-      "The banks know this. The funds know this. They've been using it on your money — and paying you almost nothing back.",
-      "Now it's your turn."
+      "Put $1,000 in a savings account a year ago, and today it's worth about… $1,003. That's the whole problem, and it isn't your fault. Nobody ever showed you the other half.",
+      "$1,000 saved is $1,000. In six months. In a year. In forty years.",
+      "But that same $1,000, left to grow, **even at a careful 7%**, could become about **$2,252 in 12 years.** You didn't add a cent. The growth started earning its own growth.",
+      "That's compound interest, the math every bank and every Wall Street firm has used for centuries.",
+      "It isn't hidden in a vault. Nobody just ever sat you down and explained it. (My grandmother did everything right for decades and was never shown this.)",
+      "It's the most powerful force in money, and almost nobody outside that world actually uses it. The talks ahead are about *why*. This one is about *how it works*."
     ]
   },
   "beat2": {
-    "title": "The system's secret engine.",
+    "title": "You don't need a fortune to start.",
     "intro": [
-      "You might be thinking — *how am I supposed to find money to invest?*",
-      "Don't worry. We won't lecture you about the old 50/30/20 rule. That worked when housing prices weren't skyrocketing, when inflation was under control, when groceries didn't cost an arm and a leg.",
-      "That world is gone. We live in this one.",
-      "So let's talk about something simpler. Small things you already spend on without thinking."
+      "You might be thinking, *where am I supposed to find money to invest?*",
+      "Fair. And we won't lecture you about the old 50/30/20 rule. That math assumed housing prices, groceries, and inflation that don't exist anymore. That world is gone. We live in this one.",
+      "So forget rules. Think about the small stuff you already spend on without thinking."
     ],
     "habitsLine": "Your daily latte. Your Friday takeout. Your monthly streaming bundle.",
-    "vignettesIntro": "If just one of those went to work instead of away, at the same 10% historical compound rate, here's what 12 years looks like:",
+    "vignettesIntro": "That was a one-time $1,000. Habits are different: they *repeat*. So picture redirecting one small habit, month after month, for 12 years. A $5-a-day coffee is about $150 a month. Kept invested at that same careful 7%, here's where each one could land:",
     "vignettes": [
       {
         "habit": "Daily latte ($5)",
@@ -53,32 +51,31 @@
     "vignettesTableHeaders": {
       "habit": "Habit",
       "yearly": "Yearly cost",
-      "twelveYear": "Could become in 12 years"
+      "twelveYear": "Could become in 12 years (estimate)"
     },
     "vignettesOutro": "Same money. Different job.",
-    "vignettesDisclaimer": "Illustrative figures based on a 10% historical compound rate. Past performance does not guarantee future results.",
-    "habitsRecap": "Nobody is asking you to give up your latte. Or your Friday takeout. Or your streaming. Keep what makes life good.",
+    "vignettesDisclaimer": "Illustrative figures assume that habit is invested in equal monthly amounts, month after month, for 12 years at a careful 7% compound rate; the historical 10% and an optimistic 14% are in the calculator below. Past performance does not guarantee future results.",
+    "habitsRecap": "Nobody's asking you to give up your latte, your takeout, or your streaming. Keep what makes life good.",
     "outro": [
-      "But if even one of these — just one — went to work for you instead of disappearing every month, the math you saw above is what happens.",
-      "This is what the banks have been doing. With your money. For decades.",
-      "Now it's your turn."
+      "But if even one of them, just one, went to work for you instead of vanishing every month, that's the math you just saw.",
+      "The banks have done this for decades. Adelaide never got shown it. Now you have."
     ]
   },
   "beat3": {
-    "title": "Now use it yourself.",
+    "title": "Now use your own numbers.",
     "intro": [
-      "The math above used a daily latte, a Friday takeout, a monthly streaming bundle. Those are examples. Your life is yours.",
-      "So plug in your own numbers.",
-      "What do you spend on, every day or every week or every month, that you wouldn't really miss if it went to work for you instead?",
-      "Your weekly takeout. Your monthly subscription stack. The few dollars you spend on the way to work without thinking. Whatever it is — type it in below.",
-      "The chart will show you what 12 years looks like. At three different rates. Compared against what your bank is paying you right now."
+      "Those were my examples: a latte, takeout, streaming. Your life is yours.",
+      "And here's the honest part: I run diBoaS, so I've got a reason to want you excited about this. Don't take my word for it.",
+      "Plug in your own numbers below, whatever you actually spend and wouldn't really miss. Pick your years. The chart shows what happens, at three different rates, next to what your bank pays you right now.",
+      "Let your own math tell you. That's the only number that matters."
     ],
     "calculatorTagline": "Same money. Different job.",
     "afterCalculator": "Numbers landed?",
     "toolDeepLink": "Want this calculator on its own? <link>Open the standalone Compound Interest tool</link>",
     "wrap": [
-      "This is what diBoaS is for. The part of your money you can set aside, working at a rate the system has been keeping for itself.",
-      "Your bank stays where it is — for spending, bills, and daily life. diBoaS is for money with a goal."
+      "That's compound interest. You just learned the single idea the whole financial system runs on, and now you can see it in your own numbers.",
+      "This is the part of your money diBoaS is built for: the part you can set aside, with a goal, working at a rate the system mostly kept for itself. Your bank stays where it is, for spending, bills, and daily life.",
+      "But there's a catch, and it's Talk 2: compound interest only works on money that has somewhere to go. Most money never gets the chance. It leaks out first. Next, we'll look at why."
     ],
     "cta": {
       "primary": "Join the Waitlist",
@@ -113,6 +110,6 @@
     "tableHeaderRate": "Annual rate",
     "tableHeaderTotal": "After {years} years",
     "loadingState": "Calculating…",
-    "calibrationNote": "What the rates mean. The 7% conservative rate is the steadier scenario, 10% historical is the mid-range, and 14% optimistic is the more active one. These are scenarios, not promises, and every rate carries risk. Independently: the S&P 500 total return has averaged about 10% a year over the long run (nominal, with dividends reinvested; roughly 7% after inflation), and gold about 7% a year. Over the long run, saving in Brazilian reais lagged holding the digital dollar (full numbers in our research notes)."
+    "calibrationNote": "What the rates mean. The 7% conservative rate is the steadier scenario, 10% historical is the mid-range, and 14% optimistic is the more active one. These are scenarios, not promises, and every rate carries risk. Independently: the S&P 500 total return has averaged about 10% a year over the long run (nominal, with dividends reinvested; roughly 7% after inflation), and gold about 7% a year (full numbers in our research notes)."
   }
 }

--- a/packages/i18n/translations/en/learn.json
+++ b/packages/i18n/translations/en/learn.json
@@ -4,7 +4,8 @@
     "description": "Short, honest lessons on the financial system, written for people the system wasn't built for."
   },
   "nav": {
-    "label": "Learn"
+    "label": "Learn",
+    "home": "Home"
   },
   "index": {
     "h1": "Learn how money actually works.",

--- a/packages/i18n/translations/es/learn-compound-interest.json
+++ b/packages/i18n/translations/es/learn-compound-interest.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "Cómo Crece el Dinero de Verdad — El interés compuesto explicado",
+    "title": "Cómo Crece el Dinero de Verdad: El interés compuesto explicado",
     "description": "Aprende cómo funciona el interés compuesto: las matemáticas que los bancos y Wall Street han usado durante décadas. Introduce tus propios números y mira cómo se ven 12 años."
   },
   "lesson": {
@@ -8,77 +8,74 @@
     "readTime": "~5 min de lectura",
     "lastUpdated": {
       "label": "Última actualización:",
-      "date": "Mayo 2026"
+      "date": "julio de 2026"
     }
   },
   "beat1": {
     "title": "Ahorrar es solo la mitad de la historia.",
     "body": [
-      "Difícil. Necesario. El primer paso. Pero, por sí solo, nunca cambia la vida.",
-      "1.000 € ahorrados siguen siendo 1.000 € dentro de seis meses. Dentro de un año. Dentro de cuarenta años.",
-      "Pero esos mismos 1.000 € podrían ser **~2.252 € en 12 años.**",
-      "¿Cómo?",
-      "Haciendo lo que cada banco y cada gran fondo lleva siglos haciendo. Usando el interés compuesto.",
-      "Los bancos lo saben. Los fondos lo saben. Llevan décadas usándolo con tu dinero — y pagándote casi nada a cambio.",
-      "Ahora te toca a ti."
+      "Metiste 1.000 € en una cuenta de ahorro hace un año, y hoy valen… unos 1.003 €. Ese es el problema entero, y no es culpa tuya. Nadie te enseñó nunca la otra mitad.",
+      "1.000 € ahorrados son 1.000 €. Dentro de seis meses. Dentro de un año. Dentro de cuarenta.",
+      "Pero esos mismos 1.000 €, dejándolos crecer, **aunque sea a un prudente 7 %**, podrían convertirse en unos **2.252 € en 12 años.** No has añadido ni un céntimo. El crecimiento empezó a generar su propio crecimiento.",
+      "Eso es el interés compuesto, las cuentas que cada banco y cada gran fondo llevan siglos usando.",
+      "No está escondido en ninguna caja fuerte. Es que nadie se sentó nunca a explicártelo. (Mi abuela lo hizo todo bien durante décadas y nadie se lo enseñó.)",
+      "Es la fuerza más potente que existe sobre el dinero, y casi nadie fuera de ese mundo la usa de verdad. Las charlas que vienen van de *por qué*. Esta va de *cómo funciona*."
     ]
   },
   "beat2": {
-    "title": "El motor secreto del sistema.",
+    "title": "No hace falta una fortuna para empezar.",
     "intro": [
-      "A lo mejor estás pensando — *¿de dónde se supone que voy a sacar dinero para invertir?*",
-      "Tranquilo. No te vamos a soltar la vieja regla del 50/30/20. Eso funcionaba cuando los pisos no estaban por las nubes, cuando la inflación estaba controlada, cuando hacer la compra no costaba un riñón.",
-      "Ese mundo ya pasó. Vivimos en este.",
-      "Así que hablemos de algo más sencillo. Pequeñas cosas en las que ya gastas sin pensar."
+      "A lo mejor estás pensando: *¿de dónde saco yo dinero para invertir?*",
+      "Normal. Y no te vamos a dar la charla de la vieja regla del 50/30/20. Esas cuentas daban por hechos unos precios de la vivienda, una compra y una inflación que ya no existen. Ese mundo se acabó. Vivimos en este.",
+      "Así que olvídate de reglas. Piensa en las cosas pequeñas en las que ya gastas sin pensar."
     ],
-    "habitsLine": "El café con tostada de cada mañana. Las cañas con amigos del finde. El streaming y el gimnasio cada mes.",
-    "vignettesIntro": "Si solo uno de esos se pusiera a trabajar para ti en vez de irse, al mismo 10 % de rentabilidad histórica, así se verían 12 años:",
+    "habitsLine": "El café de cada mañana. La comida a domicilio del viernes. El streaming de cada mes.",
+    "vignettesIntro": "Aquello eran 1.000 € una sola vez. Los hábitos son otra cosa: se *repiten*. Así que imagina redirigir un pequeño hábito, mes tras mes, durante 12 años. Un café de 1,80 € al día son unos 55 € al mes. Invertido a ese mismo prudente 7 %, esto es más o menos donde podría acabar cada uno:",
     "vignettes": [
       {
-        "habit": "Café con tostada (3 €/día)",
+        "habit": "Café cada mañana (1,80 €/día)",
+        "yearly": "650 €",
+        "yearlyAmount": "650"
+      },
+      {
+        "habit": "Comida a domicilio del viernes (15 €/semana)",
         "yearly": "780 €",
         "yearlyAmount": "780"
       },
       {
-        "habit": "Cañas con amigos (25 €/semana)",
-        "yearly": "1.300 €",
-        "yearlyAmount": "1300"
-      },
-      {
-        "habit": "Streaming + gimnasio (40 €/mes)",
-        "yearly": "480 €",
-        "yearlyAmount": "480"
+        "habit": "Streaming (20 €/mes)",
+        "yearly": "240 €",
+        "yearlyAmount": "240"
       }
     ],
     "vignettesTableHeaders": {
       "habit": "Hábito",
       "yearly": "Coste al año",
-      "twelveYear": "Podría convertirse en 12 años"
+      "twelveYear": "Podría convertirse en 12 años (estimación)"
     },
     "vignettesOutro": "Mismo dinero. Otro trabajo.",
-    "vignettesDisclaimer": "Cifras ilustrativas basadas en un 10 % de interés compuesto histórico. Rentabilidades pasadas no garantizan resultados futuros.",
-    "habitsRecap": "Nadie te está pidiendo que dejes el café. Ni las cañas. Ni el streaming. Quédate con lo que hace que la vida valga la pena.",
+    "vignettesDisclaimer": "Cifras ilustrativas: suponen que ese hábito se invierte en cantidades mensuales iguales, mes tras mes, durante 12 años a un prudente 7 % de interés compuesto; el 10 % histórico y un 14 % optimista están en la calculadora de abajo. Rentabilidades pasadas no garantizan resultados futuros. Son escenarios, no promesas.",
+    "habitsRecap": "Nadie te pide que dejes el café, la comida a domicilio ni el streaming. Quédate con lo que te hace la vida buena.",
     "outro": [
-      "Pero si solo uno de ellos — solo uno — trabajara para ti en vez de desaparecer cada mes, lo que pasa es justo la cuenta que acabas de ver arriba.",
-      "Esto es lo que los bancos llevan haciendo. Con tu dinero. Durante décadas.",
-      "Ahora te toca a ti."
+      "Pero si solo uno de ellos, solo uno, se pusiera a trabajar para ti en vez de esfumarse cada mes, esa es la cuenta que acabas de ver.",
+      "Los bancos llevan décadas haciéndolo. A Adelaide nadie se lo enseñó. Ahora ya lo sabes tú."
     ]
   },
   "beat3": {
-    "title": "Ahora úsalo tú.",
+    "title": "Ahora usa tus propios números.",
     "intro": [
-      "Las cuentas de arriba usan café, cañas y streaming. Son ejemplos. Tu vida es tuya.",
-      "Así que pon tus propios números.",
-      "¿En qué gastas, cada día, cada semana o cada mes, que no echarías de menos si trabajara para ti?",
-      "Esa cena de los viernes. Las suscripciones que se han ido acumulando. Los pocos euros que se van cada mañana de camino al trabajo. Lo que sea — escríbelo abajo.",
-      "El gráfico te enseñará cómo se ven 12 años. A tres tipos de interés diferentes. Comparado con lo que tu banco te está pagando ahora mismo."
+      "Esos eran mis ejemplos: un café, la comida a domicilio, el streaming. Tu vida es tuya.",
+      "Y aquí va la parte honesta: yo llevo diBoaS, así que tengo un motivo para querer que esto te ilusione. No te fíes de mi palabra.",
+      "Mete abajo tus propios números, lo que gastas de verdad y no echarías de menos. Elige tus años. El gráfico enseña lo que pasa, a tres tipos de interés distintos, al lado de lo que tu banco te paga ahora mismo.",
+      "Que te lo digan tus propias cuentas. Ese es el único número que importa."
     ],
     "calculatorTagline": "Mismo dinero. Otro trabajo.",
     "afterCalculator": "¿Te ha cuadrado la cuenta?",
     "toolDeepLink": "¿Quieres esta calculadora por separado? <link>Abre la calculadora de interés compuesto</link>",
     "wrap": [
-      "Para esto está diBoaS. La parte de tu dinero que puedes apartar, trabajando a un ritmo que el sistema se venía guardando solo para él.",
-      "Tu banco se queda donde está — para gastos, recibos y el día a día. diBoaS es para el dinero con un objetivo."
+      "Eso es el interés compuesto. Acabas de aprender la única idea sobre la que funciona todo el sistema financiero, y ahora la ves en tus propios números.",
+      "Esta es la parte de tu dinero para la que está hecho diBoaS: la que puedes apartar, con un objetivo, trabajando a un ritmo que el sistema se venía guardando casi todo para él. Tu banco se queda donde está, para gastos, recibos y el día a día.",
+      "Pero hay una trampa, y es la Charla 2: el interés compuesto solo funciona con dinero que tiene a dónde ir. La mayoría del dinero nunca tiene la oportunidad. Se escapa antes. La próxima vez vemos por qué."
     ],
     "cta": {
       "primary": "Apuntarme a la lista de espera",
@@ -113,6 +110,6 @@
     "tableHeaderRate": "Tipo anual",
     "tableHeaderTotal": "Después de {years} años",
     "loadingState": "Calculando…",
-    "calibrationNote": "Qué significan las tasas. El 7% conservador es el escenario más estable, el 10% histórico queda en el medio del rango de largo plazo, y el 14% optimista es el escenario más activo. Son escenarios, no promesas, y todo tipo de interés conlleva riesgo. De forma independiente: el S&P 500 retornó, de media, alrededor del 10% al año a largo plazo (nominal, con dividendos reinvertidos; cerca del 7% tras la inflación), y el oro alrededor del 7% al año. Mientras tanto, una cuenta de ahorro o un depósito en euros ha estado años pagando cerca de cero, y la inflación se va comiendo en silencio ese dinero parado (cifras completas en nuestras notas de investigación)."
+    "calibrationNote": "Qué significan los tipos. El 7 % prudente es el escenario más estable, el 10 % histórico queda en mitad del rango a largo plazo, y el 14 % optimista es el más movido. Son escenarios, no promesas, y todo tipo de interés conlleva riesgo. Como referencia independiente: el S&P 500 ha rentado de media en torno al 10 % anual a largo plazo (nominal, con dividendos reinvertidos; cerca del 7 % descontada la inflación), y el oro alrededor del 7 % anual. Mientras tanto, lo que paga una cuenta de ahorro o un depósito en euros ha estado años cerca del cero, y la inflación se va comiendo en silencio ese dinero parado (cifras completas en nuestras notas de investigación)."
   }
 }

--- a/packages/i18n/translations/es/learn.json
+++ b/packages/i18n/translations/es/learn.json
@@ -4,7 +4,8 @@
     "description": "Lecciones cortas y honestas sobre el sistema financiero, escritas para quienes el sistema dejó fuera."
   },
   "nav": {
-    "label": "Aprender"
+    "label": "Aprender",
+    "home": "Inicio"
   },
   "index": {
     "h1": "Aprende cómo funciona el dinero de verdad.",

--- a/packages/i18n/translations/pt-BR/learn-compound-interest.json
+++ b/packages/i18n/translations/pt-BR/learn-compound-interest.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "Como o Dinheiro Realmente Cresce — Juros compostos explicados",
+    "title": "Como o Dinheiro Realmente Cresce: Juros compostos explicados",
     "description": "Entenda como os juros compostos funcionam: a matemática que bancos e Wall Street usam há décadas. Coloque seus próprios números e veja como ficam 12 anos."
   },
   "lesson": {
@@ -8,77 +8,74 @@
     "readTime": "~5 min de leitura",
     "lastUpdated": {
       "label": "Última atualização:",
-      "date": "Maio 2026"
+      "date": "julho de 2026"
     }
   },
   "beat1": {
     "title": "Poupar é só metade da história.",
     "body": [
-      "Difícil. Necessário. O primeiro passo. Mas, sozinho, nunca vai mudar a sua vida.",
-      "R$ 1.000 guardados continuam sendo R$ 1.000 daqui a seis meses. Daqui a um ano. Daqui a quarenta anos.",
-      "Mas esses mesmos R$ 1.000 poderiam virar **~R$ 2.252 em 12 anos.**",
-      "Como?",
-      "Fazendo o que todo banco e toda Wall Street vêm fazendo há séculos. Usando juros compostos.",
-      "Os bancos sabem disso. Os fundos sabem disso. Eles vêm usando isso com o seu dinheiro — e te pagando quase nada em troca.",
-      "Agora é a sua vez."
+      "Você deixou R$ 1.000 na poupança um ano atrás. Hoje rendeu... um pouquinho. Mas o aluguel subiu, o mercado subiu, o dólar subiu. Na prática, seu dinheiro mal saiu do lugar. Esse é o problema todo, e a culpa não é sua. Ninguém nunca te mostrou a outra metade.",
+      "R$ 1.000 guardados continuam sendo R$ 1.000. Daqui a seis meses. Daqui a um ano. Daqui a quarenta anos. E, enquanto isso, a vida vai ficando mais cara em volta deles.",
+      "Mas esses mesmos R$ 1.000, deixados pra crescer, mesmo num ritmo cauteloso de 7%, poderiam virar uns **R$ 2.252 em 12 anos.** Você não botou nem um centavo. O crescimento começou a render em cima do próprio crescimento. Não é promessa, é cenário.",
+      "Isso são juros compostos, a conta que todo banco e todo fundo usam há séculos.",
+      "Não está escondido num cofre. Só que ninguém nunca sentou e explicou. (A minha avó fez tudo certo por décadas e nunca uma vez mostraram isso pra ela.)",
+      "É a força mais poderosa que existe sobre dinheiro, e quase ninguém fora desse mundo usa de verdade. Os próximos papos são sobre o *porquê*. Esse aqui é sobre *como funciona*."
     ]
   },
   "beat2": {
-    "title": "A engrenagem secreta do sistema.",
+    "title": "Você não precisa de uma fortuna pra começar.",
     "intro": [
-      "Você deve estar pensando — *e de onde eu vou tirar dinheiro pra investir?*",
-      "Pode ficar tranquilo. A gente não vai vir com a velha regra dos 50/30/20. Aquilo funcionava quando o aluguel não estava nas alturas, quando a inflação estava sob controle, quando o mercado não doía no bolso toda semana.",
-      "Esse mundo já era. A gente vive nesse aqui.",
-      "Então vamos falar de algo mais simples. Coisas pequenas que você já gasta sem pensar."
+      "Você deve estar pensando: *e de onde eu vou tirar dinheiro pra investir?*",
+      "Justo. E a gente não vai vir com a velha regra dos 50/30/20. Aquela conta pressupunha aluguel, mercado e inflação que não existem mais. Aquele mundo já era. A gente vive nesse aqui.",
+      "Então esquece regra. Pensa nas coisinhas que você já gasta sem nem pensar."
     ],
-    "habitsLine": "Aquele iFood do almoço. O cinema com pipoca de sábado. O combo de streaming todo mês.",
-    "vignettesIntro": "Se só um desses fosse trabalhar pra você em vez de ir embora, no mesmo rendimento histórico de 10% ao ano, olha como ficam 12 anos:",
+    "habitsLine": "O cafezinho de todo dia. A comida por app na sexta. O combo de streaming todo mês.",
+    "vignettesIntro": "Aquilo foram R$ 1.000 de uma vez só. Hábito é diferente: ele se repete. Então imagina redirecionar um hábito pequeno, mês após mês, por 12 anos. Um cafezinho de uns R$ 10 por dia dá uns R$ 200 por mês. Investido naquele mesmo ritmo cauteloso de 7%, olha onde cada um poderia chegar:",
     "vignettes": [
       {
-        "habit": "iFood no almoço (R$ 25/dia útil)",
-        "yearly": "R$ 6.500",
-        "yearlyAmount": "6500"
+        "habit": "Cafezinho de todo dia (R$ 10/dia útil)",
+        "yearly": "R$ 2.400",
+        "yearlyAmount": "2400"
       },
       {
-        "habit": "Cinema com pipoca (R$ 80/semana)",
-        "yearly": "R$ 4.160",
-        "yearlyAmount": "4160"
+        "habit": "Comida por app na sexta (R$ 50/semana)",
+        "yearly": "R$ 2.600",
+        "yearlyAmount": "2600"
       },
       {
-        "habit": "Combo de streaming (R$ 80/mês)",
-        "yearly": "R$ 960",
-        "yearlyAmount": "960"
+        "habit": "Combo de streaming (R$ 60/mês)",
+        "yearly": "R$ 720",
+        "yearlyAmount": "720"
       }
     ],
     "vignettesTableHeaders": {
       "habit": "Hábito",
       "yearly": "Custo por ano",
-      "twelveYear": "Poderia virar em 12 anos"
+      "twelveYear": "Poderia virar em 12 anos (estimativa)"
     },
     "vignettesOutro": "Mesmo dinheiro. Outro trabalho.",
-    "vignettesDisclaimer": "Valores ilustrativos baseados em 10% de juros compostos históricos. Desempenho passado não garante resultados futuros.",
-    "habitsRecap": "Ninguém está te pedindo pra cortar o iFood. Nem o cinema. Nem o streaming. Mantém o que faz a vida valer a pena.",
+    "vignettesDisclaimer": "Valores ilustrativos, considerando que o hábito é investido em parcelas mensais iguais, mês após mês, por 12 anos, a um ritmo cauteloso de 7% de juros compostos. Os 10% históricos e os 14% otimistas estão na calculadora aqui embaixo. São cenários, não promessas, e desempenho passado não garante resultado futuro.",
+    "habitsRecap": "Ninguém está te pedindo pra cortar o cafezinho, a comida por app ou o streaming. Fica com o que faz a vida valer a pena.",
     "outro": [
-      "Mas se só um deles — só um — fosse trabalhar pra você em vez de sumir todo mês, é a conta que você acabou de ver lá em cima.",
-      "É isso que os bancos vêm fazendo. Com o seu dinheiro. Há décadas.",
-      "Agora é a sua vez."
+      "Mas se só um deles, só um, fosse trabalhar pra você em vez de sumir todo mês, é a conta que você acabou de ver ali em cima.",
+      "Os bancos fazem isso há décadas. A minha avó nunca teve quem sentasse e explicasse. Agora você teve."
     ]
   },
   "beat3": {
-    "title": "Agora é a sua vez de usar.",
+    "title": "Agora, com os seus números.",
     "intro": [
-      "A conta lá em cima usou iFood, cinema e streaming. São só exemplos. A sua vida é sua.",
-      "Então coloca os seus próprios números.",
-      "No que você gasta, todo dia, toda semana ou todo mês, que você nem sentiria falta se fosse trabalhar pra você?",
-      "Aquele rolê semanal. As assinaturas que se acumularam. Os trocados que somem todo dia no caminho do trabalho. Seja o que for — coloca aí embaixo.",
-      "O gráfico vai te mostrar como ficam 12 anos. Em três cenários diferentes. Comparado com o que o seu banco está te pagando agora."
+      "Aqueles eram os meus exemplos: cafezinho, comida por app, streaming. A sua vida é sua.",
+      "E aqui vai a parte honesta: eu toco a diBoaS, então eu tenho um motivo pra querer você animado com isso. Não acredita em mim de boca.",
+      "Coloca os seus próprios números aqui embaixo, o que você de fato gasta e não sentiria falta. Escolhe os anos. O gráfico mostra o que acontece, em três cenários diferentes, do lado do que o seu banco te paga agora.",
+      "Deixa a sua própria conta te dizer. É o único número que importa."
     ],
     "calculatorTagline": "Mesmo dinheiro. Outro trabalho.",
     "afterCalculator": "As contas fizeram sentido?",
     "toolDeepLink": "Quer essa calculadora separada? <link>Abrir a calculadora de juros compostos</link>",
     "wrap": [
-      "É pra isso que existe a diBoaS. A parte do seu dinheiro que você pode separar, rendendo num ritmo que o sistema vinha guardando só pra ele.",
-      "O seu banco continua onde está — pra gastos, contas e o dia a dia. A diBoaS é pra dinheiro com um objetivo."
+      "É isso, juros compostos. Você acabou de aprender a única ideia em que o sistema financeiro inteiro se apoia, e agora consegue ver ela nos seus próprios números.",
+      "É essa a parte do seu dinheiro pra qual a diBoaS foi feita: a parte que você pode separar, com um objetivo, trabalhando num ritmo que o sistema mais guardou pra ele mesmo. O seu banco continua onde está, pra gastos, contas e o dia a dia.",
+      "Mas tem uma pegadinha, e é o Papo 2: juros compostos só funcionam com dinheiro que tem pra onde ir. A maioria do dinheiro nunca tem essa chance. Ele vaza antes. A seguir, a gente olha o porquê."
     ],
     "cta": {
       "primary": "Entrar na lista de espera",

--- a/packages/i18n/translations/pt-BR/learn.json
+++ b/packages/i18n/translations/pt-BR/learn.json
@@ -4,7 +4,8 @@
     "description": "Lições curtas e honestas sobre o sistema financeiro, escritas para quem o sistema deixou de fora."
   },
   "nav": {
-    "label": "Aprender"
+    "label": "Aprender",
+    "home": "Início"
   },
   "index": {
     "h1": "Aprenda como o dinheiro funciona de verdade.",


### PR DESCRIPTION
## What

One atomic unit: the **approved Talk 1 rework** (all 4 locales) plus the **Phase 0 bug fixes** from the learn redesign plan. Atomic because the copy-shape guard and the new JSON depend on each other (the component read fixed paragraph counts that no longer match the approved copy).

### Talk 1 content (CLO + native passed)
- `learn-compound-interest.json` ×4: the reworked Talk 1 copy; unified careful-7% narrative (founder Option A) with the recurring-contribution assumption stated; brand-free habit vignettes (removes "iFood"); 12-year column labelled an estimate; ES/DE `calibrationNote` de-contaminated (Brazilian-reais line was a pt-BR leak); EN reais sentence dropped (founder decision).
- `CalculatorVignettes`: vignette rate 10% → `SCENARIO_RATES.conservative` (7%), matching the copy. Calculator itself still shows 7/10/14.

### Phase 0 fixes
- **B-0** `LessonThreeBeat` paragraph counts → shared `BEAT_PARAGRAPH_COUNTS` contract (was 7/4/3/5/2 vs new JSON 6/3/2/4/3 → would render raw i18n keys + drop the closing paragraph).
- **B-1** JSON-LD emitted `"timeRequired": "PT[object Object]M"` → indexes the lesson value.
- **B-2** coming-soon card dropped fake-button semantics (`role="button"` no-op) → impression event instead (`learn_roadmap_card_viewed`).
- **B-3** breadcrumb JSON-LD localized (`learn.nav.home` new key ×4; wires the dead `learn.nav.label`).
- **B-4** `learn_lesson_completed` now fires (CTA group ≥50% visible, once; KPI definition documented in constants) + lesson→tool deep-link click tracked.

### Tests
First `lib/learn` coverage (was 0% vs the 80% policy floor): 10 tests across structuredData (incl. B-1 regression), registry sync-point invariants, and a 4-locale copy-shape drift guard.

## Validation
- `type-check` clean · `lint` 0 errors (20 pre-existing warnings in unrelated files) · web suite **1232/1232** · `validate:translations` green (34 files ×4 locales).
- **Rendered visual pass deferred** by founder decision; tracked as [VISUAL PASS REQUIRED] in `docs/learn/30-day-series/LEARN_REDESIGN_PLAN.md` (docs are local-only).

## Gate self-check (per CLAUDE.md)
- **Anti-slop Part 3 (rows 1–21):** copy surfaces unchanged in structure; flows/forms/selectors untouched. Rows 10–17: PASS (no urgency/herd/badges/anchoring/hostage/disguise/tinting anywhere in the change). Row 19 improved (fake-button empty-state fixed). Rows 1–9/18/20/21: PASS/N-A — the one CTA present keeps its honest note verbatim.
- **Voice rubric:** the lesson copy is the founder-approved, CLO-passed, native-passed Talk 1 (Q1–Q4 scored in `docs/audit/LEARN_BASICS_SERIES_AUDIT_2026-07-14.md`; Q3 PASS — figures labelled estimates, "scenarios, not promises", conflict-of-interest named). New strings in this PR beyond that copy: 4 × "Home" breadcrumb labels (Q1–Q4 trivially PASS).
- **Em-dash rule:** all changed strings em-dash-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)