### PR TITLE
feat(learn): Phase 3 Slice A — talk quiz, spine completion, waitlist attribution

### DIFF
--- a/apps/web/src/components/Sections/Lesson/variants/LessonThreeBeat/LessonThreeBeat.tsx
+++ b/apps/web/src/components/Sections/Lesson/variants/LessonThreeBeat/LessonThreeBeat.tsx
@@ -7,9 +7,11 @@ import { analyticsService } from '@/lib/analytics';
 import {
   LESSON_EVENTS,
   getNextLiveLesson,
+  getPrevLiveLesson,
   readMessageArray,
   type LessonMetadata,
 } from '@/lib/learn';
+import { setCtaSource } from '@/lib/analytics/ctaAttribution';
 import { SectionContainer } from '@/components/Sections/SectionContainer';
 import { LessonHero } from '@/components/UI/LessonHero';
 import { LessonProgressBar } from '@/components/UI/LessonProgressBar';
@@ -20,6 +22,7 @@ import {
   CalculatorVignettes,
   CompoundInterestCalculator,
 } from '@/components/Sections/CompoundInterestCalculator';
+import { TalkQuizFactory } from '@/components/Sections/TalkQuiz';
 import { SectionErrorBoundary } from '@/lib/errors/SectionErrorBoundary';
 import styles from './LessonThreeBeat.module.css';
 
@@ -115,6 +118,11 @@ export function LessonThreeBeat({
   };
 
   const handleWaitlistCta = () => {
+    // Phase 3 (RV-2): per-talk waitlist attribution through the existing
+    // sessionStorage machinery (mirrors DemoLauncher). Runs regardless of
+    // analytics consent: cta_source is first-party funnel context on the
+    // signup itself, same as every other CTA source.
+    setCtaSource(`learn-${lessonId}`);
     if (!enableAnalytics) return;
     analyticsService.track({
       name: LESSON_EVENTS.CTA_SECONDARY_CLICKED,
@@ -122,7 +130,24 @@ export function LessonThreeBeat({
     });
   };
 
+  const handlePrevTalkCta = () => {
+    if (!enableAnalytics) return;
+    analyticsService.track({
+      name: LESSON_EVENTS.CTA_SECONDARY_CLICKED,
+      parameters: { lessonId, locale, target: 'prev-talk', timestamp: Date.now() },
+    });
+  };
+
+  const handleToolsHubCta = () => {
+    if (!enableAnalytics) return;
+    analyticsService.track({
+      name: LESSON_EVENTS.CTA_SECONDARY_CLICKED,
+      parameters: { lessonId, locale, target: 'tools', timestamp: Date.now() },
+    });
+  };
+
   const nextTalk = getNextLiveLesson(lesson);
+  const prevTalk = getPrevLiveLesson(lesson);
 
   // B-4a: the lesson -> tool funnel edge.
   const toolHref =
@@ -302,6 +327,12 @@ export function LessonThreeBeat({
               </p>
             ))}
 
+            {/* Phase 3 quiz (registry-gated). Placed BEFORE the CTA group so
+             * the LESSON_COMPLETED sentinel keeps meaning "reached the end". */}
+            {lesson.blocks.quiz ? (
+              <TalkQuizFactory lesson={lesson} enableAnalytics={enableAnalytics} />
+            ) : null}
+
             <div className={styles.ctaGroup} ref={ctaGroupRef}>
               {/* Hash-only href: CTAButtonLink wraps internal hrefs in plain
                * next/link, so `#beat3` scrolls same-page natively without
@@ -321,9 +352,34 @@ export function LessonThreeBeat({
                     { title: intl.formatMessage({ id: `learn.arc.${nextTalk.id}.title` }) }
                   )}
                 </LocaleLink>
-              ) : (
+              ) : lesson.next ? (
                 <p className={styles.ctaFallback}>{t('beat3.cta.secondary')}</p>
+              ) : (
+                /* D-P3-1: the last talk in the spine points forward to the
+                 * tools hub; the "more talks are on the way" line would be
+                 * false once the series is complete. */
+                <LocaleLink
+                  href="/tools"
+                  className={styles.ctaSecondary}
+                  onClick={handleToolsHubCta}
+                  prefetch={false}
+                >
+                  {t('beat3.cta.toolsHub')}
+                </LocaleLink>
               )}
+              {prevTalk ? (
+                <LocaleLink
+                  href={`/learn/${prevTalk.slug}`}
+                  className={styles.ctaTertiary}
+                  onClick={handlePrevTalkCta}
+                  prefetch={false}
+                >
+                  {intl.formatMessage(
+                    { id: `${ns}.beat3.cta.prev` },
+                    { title: intl.formatMessage({ id: `learn.arc.${prevTalk.id}.title` }) }
+                  )}
+                </LocaleLink>
+              ) : null}
               <LocaleLink
                 href={waitlistCtaHref}
                 className={styles.ctaTertiary}

--- a/apps/web/src/components/Sections/TalkQuiz/TalkQuiz.stories.tsx
+++ b/apps/web/src/components/Sections/TalkQuiz/TalkQuiz.stories.tsx
@@ -1,0 +1,49 @@
+/**
+ * TalkQuiz Storybook Stories
+ *
+ * Retrieval-practice quiz for talk pages (Phase 3, Slice A). Correctness
+ * comes from the lesson registry (`blocks.quiz.correctIndexes`); all display
+ * strings resolve from i18n (`learn.quiz.*` chrome + the talk namespace's
+ * `quiz.*` content), so the locale switcher exercises all 4 locales.
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { LESSONS } from '@/lib/learn';
+import { TalkQuizFactory } from './TalkQuizFactory';
+
+const meta: Meta<typeof TalkQuizFactory> = {
+  title: 'Sections/TalkQuiz',
+  component: TalkQuizFactory,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+# TalkQuiz
+
+Two graded multiple-choice questions with instant honest feedback (no
+retries-gating, no score-shaming), an ungraded reflection prompt (never a
+data capture), and a copy-to-share line (never share-to-unlock). One
+answer per question; the aggregate-only \`learn_quiz_submitted\` event
+fires when the last graded answer lands.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    enableAnalytics: {
+      control: 'boolean',
+      description: 'Enable analytics tracking',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TalkQuizFactory>;
+
+export const Talk1: Story = {
+  args: {
+    lesson: LESSONS['compound-interest'],
+    enableAnalytics: false,
+  },
+};

--- a/apps/web/src/components/Sections/TalkQuiz/TalkQuizFactory.tsx
+++ b/apps/web/src/components/Sections/TalkQuiz/TalkQuizFactory.tsx
@@ -1,0 +1,38 @@
+/**
+ * TalkQuizFactory — variant selector for the talk-page quiz (Phase 3 of the
+ * learn redesign plan, Slice A).
+ *
+ * Retrieval practice, never a test to game: graded questions give instant
+ * honest feedback (no retries-gating, no score-shaming), the reflection is a
+ * noticing exercise (never a data capture), and the share line is an offered
+ * result, never share-to-unlock (anti-slop row 15 inverse).
+ *
+ * Correctness lives in the registry (`lesson.blocks.quiz.correctIndexes`,
+ * RV-4: one source of truth for all locales); i18n carries only display
+ * strings. A talk without a quiz block renders nothing.
+ */
+
+import type { LessonMetadata } from '@/lib/learn';
+import { TalkQuizDefault } from './variants/TalkQuizDefault';
+
+interface TalkQuizFactoryProps {
+  variant?: 'default';
+  lesson: LessonMetadata;
+  enableAnalytics?: boolean;
+}
+
+export function TalkQuizFactory({
+  variant = 'default',
+  lesson,
+  enableAnalytics,
+}: TalkQuizFactoryProps) {
+  if (!lesson.blocks.quiz?.correctIndexes.length) {
+    return null;
+  }
+
+  switch (variant) {
+    case 'default':
+    default:
+      return <TalkQuizDefault lesson={lesson} enableAnalytics={enableAnalytics} />;
+  }
+}

--- a/apps/web/src/components/Sections/TalkQuiz/__tests__/TalkQuizDefault.test.tsx
+++ b/apps/web/src/components/Sections/TalkQuiz/__tests__/TalkQuizDefault.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * TalkQuizDefault — render + behavior + analytics contract (Phase 3 Slice A).
+ *
+ * - Fieldset per graded question, options as native buttons, reflection as
+ *   plain text (no input, never a data capture).
+ * - One answer per question; feedback + correct option revealed; no retries.
+ * - `learn_quiz_submitted` fires exactly once, when the LAST graded answer
+ *   lands, with the aggregate correctCount only.
+ * - Share copies line + canonical URL; failure path is quiet.
+ *
+ * @vitest-environment happy-dom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { analyticsService } from '@/lib/analytics';
+import { LESSON_EVENTS, LESSONS } from '@/lib/learn';
+
+// Inside the hoisted factory (vi.mock is hoisted above imports, so the
+// catalog must live inside it, not in outer scope).
+vi.mock('@diboas/i18n/client', () => {
+  const CATALOG: Record<string, string> = {
+    'learn-compound-interest.quiz.q1.options.0': 'q1-opt-a',
+    'learn-compound-interest.quiz.q1.options.1': 'q1-opt-b',
+    'learn-compound-interest.quiz.q1.options.2': 'q1-opt-c',
+    'learn-compound-interest.quiz.q2.options.0': 'q2-opt-a',
+    'learn-compound-interest.quiz.q2.options.1': 'q2-opt-b',
+    'learn-compound-interest.quiz.q2.options.2': 'q2-opt-c',
+  };
+  return {
+    useTranslation: () => ({
+      locale: 'en',
+      messages: CATALOG,
+      // Catalog value when present (options), id-echo otherwise (chrome), and
+      // id+values for ICU strings (score line) so assertions stay exact.
+      formatMessage: ({ id }: { id: string }, values?: Record<string, unknown>) =>
+        values ? `${id} ${JSON.stringify(values)}` : (CATALOG[id] ?? id),
+    }),
+  };
+});
+vi.mock('@/lib/analytics', () => ({ analyticsService: { track: vi.fn() } }));
+
+import { TalkQuizDefault } from '../variants/TalkQuizDefault';
+import { TalkQuizFactory } from '../TalkQuizFactory';
+
+const mockTrack = vi.mocked(analyticsService.track);
+const talk1 = LESSONS['compound-interest'];
+
+// Registry contract this suite assumes (drift-guarded in registryHelpers too).
+const CORRECT = talk1.blocks.quiz!.correctIndexes; // [1, 0]
+
+function optionButton(label: string): HTMLButtonElement {
+  return screen.getByText(label) as HTMLButtonElement;
+}
+
+describe('TalkQuizDefault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should render one fieldset per graded question, the reflection, and no inputs', () => {
+    const { container } = render(<TalkQuizDefault lesson={talk1} enableAnalytics={false} />);
+    expect(container.querySelectorAll('fieldset')).toHaveLength(CORRECT.length);
+    expect(screen.getByText('learn-compound-interest.quiz.reflection')).toBeTruthy();
+    expect(container.querySelectorAll('input, textarea, select')).toHaveLength(0);
+  });
+
+  it('should give correct feedback and reveal the right option, one answer per question', () => {
+    render(<TalkQuizDefault lesson={talk1} enableAnalytics={false} />);
+    fireEvent.click(optionButton('q1-opt-b')); // correct (index 1)
+    expect(screen.getByText('learn.quiz.correct')).toBeTruthy();
+    expect(optionButton('q1-opt-b').dataset.state).toBe('correct');
+    expect(optionButton('q1-opt-a').disabled).toBe(true);
+    // Second click on the same question is a no-op (buttons disabled).
+    fireEvent.click(optionButton('q1-opt-a'));
+    expect(optionButton('q1-opt-a').dataset.state).toBe('muted');
+  });
+
+  it('should mark a wrong choice incorrect AND still reveal the correct option', () => {
+    render(<TalkQuizDefault lesson={talk1} enableAnalytics={false} />);
+    fireEvent.click(optionButton('q1-opt-c')); // wrong
+    expect(screen.getByText('learn.quiz.incorrect')).toBeTruthy();
+    expect(optionButton('q1-opt-c').dataset.state).toBe('incorrect');
+    expect(optionButton('q1-opt-b').dataset.state).toBe('correct');
+  });
+
+  it.each([
+    [['q1-opt-b', 'q2-opt-a'], 2],
+    [['q1-opt-b', 'q2-opt-c'], 1],
+    [['q1-opt-a', 'q2-opt-b'], 0],
+  ])('should fire learn_quiz_submitted once with correctCount (%s -> %i)', (clicks, expected) => {
+    render(<TalkQuizDefault lesson={talk1} />);
+    fireEvent.click(optionButton(clicks[0]));
+    expect(mockTrack).not.toHaveBeenCalled(); // only 1 of 2 answered
+    fireEvent.click(optionButton(clicks[1]));
+    const calls = mockTrack.mock.calls.filter(([e]) => e.name === LESSON_EVENTS.QUIZ_SUBMITTED);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].parameters?.correctCount).toBe(expected);
+    // Score line renders with registry-driven total.
+    expect(
+      screen.getByText(`learn.quiz.score {"count":${expected},"total":${CORRECT.length}}`)
+    ).toBeTruthy();
+  });
+
+  it('should copy the share line + canonical URL and swap the label', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
+    render(<TalkQuizDefault lesson={talk1} />);
+    fireEvent.click(screen.getByText('learn.quiz.share.button'));
+    await waitFor(() => expect(screen.getByText('learn.quiz.share.copied')).toBeTruthy());
+    expect(writeText.mock.calls[0][0]).toContain('learn-compound-interest.quiz.share.line');
+    expect(
+      mockTrack.mock.calls.filter(([e]) => e.name === LESSON_EVENTS.SHARE_COPIED)
+    ).toHaveLength(1);
+  });
+
+  it('should fail quietly when the clipboard is unavailable', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    });
+    render(<TalkQuizDefault lesson={talk1} />);
+    fireEvent.click(screen.getByText('learn.quiz.share.button'));
+    await waitFor(() => expect(screen.getByText('learn.quiz.share.copyFailed')).toBeTruthy());
+    expect(
+      mockTrack.mock.calls.filter(([e]) => e.name === LESSON_EVENTS.SHARE_COPIED)
+    ).toHaveLength(0);
+  });
+
+  it('should fire nothing when analytics is disabled', () => {
+    render(<TalkQuizDefault lesson={talk1} enableAnalytics={false} />);
+    fireEvent.click(optionButton('q1-opt-b'));
+    fireEvent.click(optionButton('q2-opt-a'));
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('Factory should render nothing for a talk without a quiz block', () => {
+    const { container } = render(
+      <TalkQuizFactory lesson={LESSONS['money-objective']} enableAnalytics={false} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/apps/web/src/components/Sections/TalkQuiz/index.ts
+++ b/apps/web/src/components/Sections/TalkQuiz/index.ts
@@ -1,0 +1,1 @@
+export { TalkQuizFactory } from './TalkQuizFactory';

--- a/apps/web/src/components/Sections/TalkQuiz/variants/TalkQuizDefault/TalkQuizDefault.module.css
+++ b/apps/web/src/components/Sections/TalkQuiz/variants/TalkQuizDefault/TalkQuizDefault.module.css
@@ -1,0 +1,150 @@
+/* TalkQuiz — retrieval practice in the talk's own voice. Quiet card, no
+   gamification chrome; state is shown by border + text, never by score
+   theatrics. All values tokenized. */
+
+.quiz {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-xl);
+  background: var(--color-slate-50);
+  border: 1px solid var(--color-slate-200);
+  margin-top: var(--spacing-lg);
+  font-family: var(--font-family-primary);
+}
+
+.title {
+  font-family: var(--font-family-display);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-slate-900);
+  margin: 0;
+}
+
+.question {
+  border: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.legend {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-slate-800);
+  padding: 0;
+  margin-bottom: var(--spacing-sm);
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.option {
+  text-align: left;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-slate-300);
+  background: var(--color-white);
+  color: var(--color-slate-800);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-primary);
+  cursor: pointer;
+  transition: border-color 150ms ease;
+}
+
+.option:hover:not(:disabled),
+.option:focus-visible {
+  border-color: var(--color-teal-500);
+}
+
+.option:focus-visible {
+  outline: 2px solid var(--color-teal-500);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .option {
+    transition: none;
+  }
+}
+
+.option:disabled {
+  cursor: default;
+}
+
+.option[data-state='correct'] {
+  border-color: var(--color-teal-600);
+  background: var(--teal-overlay-12);
+  color: var(--color-slate-900);
+}
+
+.option[data-state='incorrect'] {
+  border-color: var(--color-coral-600);
+  color: var(--color-slate-700);
+}
+
+.option[data-state='muted'] {
+  color: var(--color-slate-500);
+}
+
+.feedback {
+  min-height: var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-600);
+  margin: var(--spacing-xs) 0 0;
+}
+
+.score {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-slate-700);
+  margin: 0;
+}
+
+.reflection {
+  font-size: var(--font-size-md);
+  color: var(--color-slate-700);
+  line-height: 1.6;
+  margin: 0;
+  padding-top: var(--spacing-sm);
+  border-top: 1px solid var(--color-slate-200);
+}
+
+.share {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  align-items: flex-start;
+}
+
+.shareLine {
+  font-size: var(--font-size-sm);
+  color: var(--color-slate-600);
+  font-style: italic;
+  margin: 0;
+}
+
+.shareButton {
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-slate-300);
+  background: var(--color-white);
+  color: var(--color-slate-700);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-primary);
+  cursor: pointer;
+}
+
+.shareButton:hover,
+.shareButton:focus-visible {
+  border-color: var(--color-teal-500);
+  color: var(--color-teal-700);
+}
+
+.shareButton:focus-visible {
+  outline: 2px solid var(--color-teal-500);
+  outline-offset: 2px;
+}

--- a/apps/web/src/components/Sections/TalkQuiz/variants/TalkQuizDefault/TalkQuizDefault.tsx
+++ b/apps/web/src/components/Sections/TalkQuiz/variants/TalkQuizDefault/TalkQuizDefault.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from '@diboas/i18n/client';
+import { isValidLocale, type SupportedLocale } from '@diboas/i18n/config';
+import { analyticsService } from '@/lib/analytics';
+import { LESSON_EVENTS, readMessageArray, type LessonMetadata } from '@/lib/learn';
+import styles from './TalkQuizDefault.module.css';
+
+interface TalkQuizDefaultProps {
+  lesson: LessonMetadata;
+  enableAnalytics?: boolean;
+}
+
+type ShareState = 'idle' | 'copied' | 'failed';
+
+/**
+ * The talk quiz: N graded multiple-choice questions (N = the registry's
+ * correctIndexes length) + an ungraded reflection + a copy-to-share line.
+ *
+ * One answer per question (retrieval practice: changing after seeing the
+ * answer is noise). Feedback is announced via aria-live. The single
+ * `learn_quiz_submitted` event fires when the last graded answer lands and
+ * carries only the aggregate correctCount (never per-question answers).
+ */
+export function TalkQuizDefault({ lesson, enableAnalytics = true }: TalkQuizDefaultProps) {
+  const intl = useTranslation();
+  const locale: SupportedLocale = isValidLocale(intl.locale) ? intl.locale : 'en';
+
+  const ns = lesson.namespace;
+  const lessonId = lesson.id;
+  const correctIndexes = lesson.blocks.quiz?.correctIndexes ?? [];
+
+  const t = (key: string) => intl.formatMessage({ id: `${ns}.${key}` });
+  const chrome = (key: string, values?: Record<string, string | number>) =>
+    intl.formatMessage({ id: `learn.quiz.${key}` }, values);
+  const tArray = (key: string): string[] =>
+    readMessageArray(intl.messages as Record<string, unknown>, `${ns}.${key}`, (id) =>
+      intl.formatMessage({ id })
+    );
+
+  const [answers, setAnswers] = useState<ReadonlyArray<number | null>>(() =>
+    correctIndexes.map(() => null)
+  );
+  const [shareState, setShareState] = useState<ShareState>('idle');
+
+  const submittedRef = useRef(false);
+  const shareTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (shareTimerRef.current) clearTimeout(shareTimerRef.current);
+    };
+  }, []);
+
+  const allAnswered = answers.every((a) => a !== null);
+  const correctCount = answers.filter((a, i) => a === correctIndexes[i]).length;
+
+  const handleAnswer = (questionIndex: number, optionIndex: number) => {
+    setAnswers((prev) => {
+      if (prev[questionIndex] !== null) return prev;
+      const next = prev.map((a, i) => (i === questionIndex ? optionIndex : a));
+
+      if (enableAnalytics && !submittedRef.current && next.every((a) => a !== null)) {
+        submittedRef.current = true;
+        analyticsService.track({
+          name: LESSON_EVENTS.QUIZ_SUBMITTED,
+          parameters: {
+            lessonId,
+            locale,
+            correctCount: next.filter((a, i) => a === correctIndexes[i]).length,
+            timestamp: Date.now(),
+          },
+        });
+      }
+      return next;
+    });
+  };
+
+  const handleShare = async () => {
+    const url = `${window.location.origin}${window.location.pathname}`;
+    try {
+      await navigator.clipboard.writeText(`${t('quiz.share.line')} ${url}`);
+      setShareState('copied');
+      if (enableAnalytics) {
+        analyticsService.track({
+          name: LESSON_EVENTS.SHARE_COPIED,
+          parameters: { lessonId, locale, timestamp: Date.now() },
+        });
+      }
+    } catch {
+      setShareState('failed');
+    }
+    if (shareTimerRef.current) clearTimeout(shareTimerRef.current);
+    shareTimerRef.current = setTimeout(() => setShareState('idle'), 2000);
+  };
+
+  const shareLabel =
+    shareState === 'copied'
+      ? chrome('share.copied')
+      : shareState === 'failed'
+        ? chrome('share.copyFailed')
+        : chrome('share.button');
+
+  return (
+    <section className={styles.quiz} aria-labelledby="talk-quiz-title">
+      <h2 id="talk-quiz-title" className={styles.title}>
+        {chrome('title')}
+      </h2>
+
+      {correctIndexes.map((correctIndex, questionIndex) => {
+        const qKey = `q${questionIndex + 1}`;
+        const options = tArray(`quiz.${qKey}.options`);
+        const chosen = answers[questionIndex];
+        const answered = chosen !== null;
+
+        return (
+          <fieldset key={qKey} className={styles.question}>
+            <legend className={styles.legend}>{t(`quiz.${qKey}.question`)}</legend>
+            <div className={styles.options}>
+              {options.map((option, optionIndex) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={styles.option}
+                  disabled={answered}
+                  data-state={
+                    answered
+                      ? optionIndex === correctIndex
+                        ? 'correct'
+                        : optionIndex === chosen
+                          ? 'incorrect'
+                          : 'muted'
+                      : 'idle'
+                  }
+                  onClick={() => handleAnswer(questionIndex, optionIndex)}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+            <p className={styles.feedback} aria-live="polite">
+              {answered ? (chosen === correctIndex ? chrome('correct') : chrome('incorrect')) : ''}
+            </p>
+          </fieldset>
+        );
+      })}
+
+      {allAnswered ? (
+        <p className={styles.score}>
+          {chrome('score', { count: correctCount, total: correctIndexes.length })}
+        </p>
+      ) : null}
+
+      <p className={styles.reflection}>{t('quiz.reflection')}</p>
+
+      <div className={styles.share}>
+        <p className={styles.shareLine}>{t('quiz.share.line')}</p>
+        <button type="button" className={styles.shareButton} onClick={handleShare}>
+          {shareLabel}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/Sections/TalkQuiz/variants/TalkQuizDefault/index.ts
+++ b/apps/web/src/components/Sections/TalkQuiz/variants/TalkQuizDefault/index.ts
@@ -1,0 +1,1 @@
+export { TalkQuizDefault } from './TalkQuizDefault';

--- a/apps/web/src/lib/learn/__tests__/registryHelpers.test.ts
+++ b/apps/web/src/lib/learn/__tests__/registryHelpers.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
-import { LESSONS, getSeriesLessons, getNextLiveLesson } from '../registry';
+import { LESSONS, getSeriesLessons, getNextLiveLesson, getPrevLiveLesson } from '../registry';
 import type { LessonId, LessonMetadata } from '../types';
 
 function makeLesson(id: LessonId, overrides: Partial<LessonMetadata> = {}): LessonMetadata {
@@ -113,5 +113,72 @@ describe('arc i18n drift guard (registry <-> learn.arc.*)', () => {
     const entry = learnJson.arc?.[id] as { title?: unknown; line?: unknown } | undefined;
     expect(typeof entry?.title, `learn.arc.${id}.title missing in en`).toBe('string');
     expect(typeof entry?.line, `learn.arc.${id}.line missing in en`).toBe('string');
+  });
+});
+
+describe('getPrevLiveLesson (Phase 3 mirror)', () => {
+  it('should return the previous talk when it is live', () => {
+    const prev = makeLesson('compound-interest', { status: 'live', next: 'money-objective' });
+    const current = makeLesson('money-objective', { status: 'live', prev: 'compound-interest' });
+    expect(
+      getPrevLiveLesson(current, { 'compound-interest': prev, 'money-objective': current })?.id
+    ).toBe('compound-interest');
+  });
+
+  it('should return undefined when the previous talk is only announced', () => {
+    const prev = makeLesson('compound-interest', { next: 'money-objective' });
+    const current = makeLesson('money-objective', { status: 'live', prev: 'compound-interest' });
+    expect(
+      getPrevLiveLesson(current, { 'compound-interest': prev, 'money-objective': current })
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for the first talk (no prev)', () => {
+    expect(getPrevLiveLesson(LESSONS['compound-interest'])).toBeUndefined();
+  });
+});
+
+describe('quiz drift guards (registry <-> en quiz keys, RV-4)', () => {
+  const enDir = join(findTranslationsDir(), 'en');
+
+  function enNamespace(ns: string): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(enDir, `${ns}.json`), 'utf-8')) as Record<string, unknown>;
+  }
+
+  it.each(Object.values(LESSONS).filter((l) => l.blocks.quiz))(
+    'talk "$id": every correctIndex is in bounds of the en option list and questions exist',
+    (lesson) => {
+      const json = enNamespace(lesson.namespace) as {
+        quiz?: Record<string, { question?: string; options?: string[] }> & {
+          reflection?: string;
+          share?: { line?: string };
+        };
+      };
+      expect(
+        json.quiz,
+        `${lesson.namespace} has a registry quiz but no en quiz block`
+      ).toBeTruthy();
+      lesson.blocks.quiz!.correctIndexes.forEach((correctIndex, i) => {
+        const q = json.quiz![`q${i + 1}`] as { question?: string; options?: string[] };
+        expect(q?.question, `quiz.q${i + 1}.question missing in en`).toBeTypeOf('string');
+        expect(Array.isArray(q?.options), `quiz.q${i + 1}.options missing in en`).toBe(true);
+        expect(
+          correctIndex,
+          `correctIndex ${correctIndex} out of bounds for q${i + 1}`
+        ).toBeLessThan(q!.options!.length);
+        expect(correctIndex).toBeGreaterThanOrEqual(0);
+      });
+      expect(json.quiz!.reflection, 'quiz.reflection missing').toBeTypeOf('string');
+      expect(json.quiz!.share?.line, 'quiz.share.line missing').toBeTypeOf('string');
+    }
+  );
+
+  it('should have a registry quiz block for every LIVE talk namespace that ships quiz keys (two-way seam)', () => {
+    for (const lesson of Object.values(LESSONS).filter((l) => l.status === 'live')) {
+      const json = enNamespace(lesson.namespace) as { quiz?: unknown };
+      const hasKeys = Boolean(json.quiz);
+      const hasRegistry = Boolean(lesson.blocks.quiz);
+      expect(hasKeys, `"${lesson.id}": quiz keys/registry mismatch`).toBe(hasRegistry);
+    }
   });
 });

--- a/apps/web/src/lib/learn/constants.ts
+++ b/apps/web/src/lib/learn/constants.ts
@@ -27,6 +27,11 @@ export const LESSON_EVENTS = {
   CTA_PRIMARY_CLICKED: 'learn_cta_primary_clicked',
   CTA_SECONDARY_CLICKED: 'learn_cta_secondary_clicked',
   TOOL_DEEPLINK_CLICKED: 'learn_tool_deeplink_clicked',
+  // Phase 3 (Slice A). QUIZ_SUBMITTED fires ONCE per mount when the last
+  // graded answer lands; payload carries correctCount only (never the
+  // per-question answers: non-sensitive by design).
+  QUIZ_SUBMITTED: 'learn_quiz_submitted',
+  SHARE_COPIED: 'learn_share_copied',
 } as const;
 
 export type LessonEventName = (typeof LESSON_EVENTS)[keyof typeof LESSON_EVENTS];

--- a/apps/web/src/lib/learn/index.ts
+++ b/apps/web/src/lib/learn/index.ts
@@ -13,6 +13,7 @@ export {
   getAnnouncedLessons,
   getSeriesLessons,
   getNextLiveLesson,
+  getPrevLiveLesson,
 } from './registry';
 export { LESSON_EVENTS, type LessonEventName } from './constants';
 export { readMessageArray } from './i18nArrays';

--- a/apps/web/src/lib/learn/registry.ts
+++ b/apps/web/src/lib/learn/registry.ts
@@ -29,6 +29,8 @@ export const LESSONS: Readonly<Record<LessonId, LessonMetadata>> = {
       beat3Tool: { kind: 'embeddedCalculator' },
       extraNamespaces: ['tools-shared'], // UsdEquivalentBadge inside the embedded calculator
       needsMarketData: true, // A8: prime the market snapshot before render
+      // Approved Talk-1 quiz (docs §5): Q1 correct = (b), Q2 correct = (a).
+      quiz: { correctIndexes: [1, 0] },
     },
   },
   'money-objective': {
@@ -150,4 +152,16 @@ export function getNextLiveLesson(
 ): LessonMetadata | undefined {
   const next = lesson.next ? lessons[lesson.next] : undefined;
   return next?.status === 'live' ? next : undefined;
+}
+
+/**
+ * The previous talk in the spine ONLY if it is live (Phase 3 mirror of
+ * getNextLiveLesson: a prev link to an announced talk would 404).
+ */
+export function getPrevLiveLesson(
+  lesson: LessonMetadata,
+  lessons: Readonly<Partial<Record<LessonId, LessonMetadata>>> = LESSONS
+): LessonMetadata | undefined {
+  const prev = lesson.prev ? lessons[lesson.prev] : undefined;
+  return prev?.status === 'live' ? prev : undefined;
 }

--- a/apps/web/src/lib/learn/types.ts
+++ b/apps/web/src/lib/learn/types.ts
@@ -46,6 +46,14 @@ export interface LessonBlocks {
   extraNamespaces?: string[];
   /** Whether the page must prefetch the market snapshot (Talk 1: yes, A8). */
   needsMarketData?: boolean;
+  /**
+   * Graded quiz: correct-option indexes (0-based), one per graded question
+   * (Phase 3, RV-4). One source of truth for ALL locales; i18n carries only
+   * display strings (`quiz.qN.question` + until-exhausted `quiz.qN.options`).
+   * Option order is fixed by the approved talk docs; translators must never
+   * reorder options. Absent = the talk renders no quiz.
+   */
+  quiz?: { correctIndexes: readonly number[] };
 }
 
 export interface LessonMetadata {

--- a/packages/i18n/translations/de/learn-compound-interest.json
+++ b/packages/i18n/translations/de/learn-compound-interest.json
@@ -82,7 +82,9 @@
       "primaryNote": "Du musst kein Geld bewegen, um auf die Warteliste zu kommen. Du entscheidest später.",
       "next": "Nächster Talk: {title}",
       "waitlist": "Auf die Warteliste",
-      "secondary": "Weitere Talks kommen"
+      "secondary": "Weitere Talks kommen",
+      "prev": "Zurück zu: {title}",
+      "toolsHub": "Mach mit den Tools weiter"
     }
   },
   "calculator": {
@@ -113,5 +115,23 @@
     "tableHeaderTotal": "Nach {years} Jahren",
     "loadingState": "Wird berechnet…",
     "calibrationNote": "Was die Zinssätze bedeuten. Die vorsichtigen 7 % sind das stabilere Szenario, die historischen 10 % liegen langfristig in der Mitte, die optimistischen 14 % sind das bewegtere. Das sind Szenarien, keine Versprechen, und jede Rate trägt Risiko. Zur Einordnung: Der S&P 500 erzielte langfristig im Schnitt rund 10 % pro Jahr (nominal, mit reinvestierten Dividenden; rund 7 % nach Inflation), Gold rund 7 % pro Jahr. Deine Bank zahlt seit Jahren nahe null, während die Inflation dein Erspartes still auffrisst (vollständige Zahlen in unseren Recherche-Notizen)."
+  },
+  "quiz": {
+    "q1": {
+      "question": "Was macht Zinseszins anders als einfaches Sparen?",
+      "options": [
+        "du legst jeden Monat Geld dazu",
+        "der Zuwachs fängt an, seinen eigenen Zuwachs zu verdienen",
+        "die Bank garantiert es"
+      ]
+    },
+    "q2": {
+      "question": "Das Beispiel von 1.000 € zu ~2.252 € hat welchen Zinssatz genutzt?",
+      "options": ["vorsichtige 7 %", "garantierte 20 %", "was auch immer die Bank verspricht"]
+    },
+    "reflection": "Schau dir den letzten Monat an und nenne eine kleine Ausgabe, die du nicht wirklich vermissen würdest. Kein Druck, etwas zu ändern. Nimm es einfach nur wahr.",
+    "share": {
+      "line": "Stellt sich raus: Die stärkste Idee im ganzen Thema Geld versteht man in etwa 5 Minuten. Hier ist Talk 1."
+    }
   }
 }

--- a/packages/i18n/translations/de/learn.json
+++ b/packages/i18n/translations/de/learn.json
@@ -45,5 +45,16 @@
       "title": "Alles zusammen.",
       "line": "Du hast die Grundlagen."
     }
+  },
+  "quiz": {
+    "title": "Kurz nachgehakt",
+    "correct": "Genau die.",
+    "incorrect": "Nicht ganz.",
+    "score": "{count} von {total}",
+    "share": {
+      "button": "Zum Teilen kopieren",
+      "copied": "Kopiert",
+      "copyFailed": "Kopieren ging nicht"
+    }
   }
 }

--- a/packages/i18n/translations/en/learn-compound-interest.json
+++ b/packages/i18n/translations/en/learn-compound-interest.json
@@ -82,7 +82,9 @@
       "primaryNote": "Joining doesn't move your money. You decide later.",
       "next": "Next talk: {title}",
       "waitlist": "Join the waitlist",
-      "secondary": "More talks are on the way"
+      "secondary": "More talks are on the way",
+      "prev": "Back to: {title}",
+      "toolsHub": "Keep going with the tools"
     }
   },
   "calculator": {
@@ -113,5 +115,23 @@
     "tableHeaderTotal": "After {years} years",
     "loadingState": "Calculating…",
     "calibrationNote": "What the rates mean. The 7% conservative rate is the steadier scenario, 10% historical is the mid-range, and 14% optimistic is the more active one. These are scenarios, not promises, and every rate carries risk. Independently: the S&P 500 total return has averaged about 10% a year over the long run (nominal, with dividends reinvested; roughly 7% after inflation), and gold about 7% a year (full numbers in our research notes)."
+  },
+  "quiz": {
+    "q1": {
+      "question": "What makes compound interest different from just saving?",
+      "options": [
+        "you add money each month",
+        "the growth starts earning its own growth",
+        "the bank guarantees it"
+      ]
+    },
+    "q2": {
+      "question": "The $1,000 to ~$2,252 example used which rate?",
+      "options": ["a careful 7%", "a guaranteed 20%", "whatever the bank promises"]
+    },
+    "reflection": "Look at last month and name one small spend you wouldn't really miss. No pressure to change it. Just notice it.",
+    "share": {
+      "line": "Turns out the most powerful idea in money takes about 5 minutes to get. Here's Talk 1."
+    }
   }
 }

--- a/packages/i18n/translations/en/learn.json
+++ b/packages/i18n/translations/en/learn.json
@@ -45,5 +45,16 @@
       "title": "Putting it together.",
       "line": "You've got the Basics."
     }
+  },
+  "quiz": {
+    "title": "Quick check",
+    "correct": "That's the one.",
+    "incorrect": "Not quite.",
+    "score": "{count} of {total}",
+    "share": {
+      "button": "Copy to share",
+      "copied": "Copied",
+      "copyFailed": "Couldn't copy"
+    }
   }
 }

--- a/packages/i18n/translations/es/learn-compound-interest.json
+++ b/packages/i18n/translations/es/learn-compound-interest.json
@@ -82,7 +82,9 @@
       "primaryNote": "Apuntarte no mueve tu dinero. Tú decides después.",
       "next": "Siguiente charla: {title}",
       "waitlist": "Apuntarme a la lista de espera",
-      "secondary": "Vendrán más charlas"
+      "secondary": "Vendrán más charlas",
+      "prev": "Volver a: {title}",
+      "toolsHub": "Sigue con las herramientas"
     }
   },
   "calculator": {
@@ -113,5 +115,23 @@
     "tableHeaderTotal": "Después de {years} años",
     "loadingState": "Calculando…",
     "calibrationNote": "Qué significan los tipos. El 7 % prudente es el escenario más estable, el 10 % histórico queda en mitad del rango a largo plazo, y el 14 % optimista es el más movido. Son escenarios, no promesas, y todo tipo de interés conlleva riesgo. Como referencia independiente: el S&P 500 ha rentado de media en torno al 10 % anual a largo plazo (nominal, con dividendos reinvertidos; cerca del 7 % descontada la inflación), y el oro alrededor del 7 % anual. Mientras tanto, lo que paga una cuenta de ahorro o un depósito en euros ha estado años cerca del cero, y la inflación se va comiendo en silencio ese dinero parado (cifras completas en nuestras notas de investigación)."
+  },
+  "quiz": {
+    "q1": {
+      "question": "¿Qué hace que el interés compuesto sea distinto de solo ahorrar?",
+      "options": [
+        "que añades dinero cada mes",
+        "que el crecimiento empieza a generar su propio crecimiento",
+        "que el banco lo garantiza"
+      ]
+    },
+    "q2": {
+      "question": "El ejemplo de 1.000 € a ~2.252 €, ¿qué tipo de interés usó?",
+      "options": ["un prudente 7 %", "un 20 % garantizado", "lo que prometa el banco"]
+    },
+    "reflection": "Mira el mes pasado y señala un pequeño gasto que no echarías de menos. Sin presión por cambiarlo. Solo fíjate en él.",
+    "share": {
+      "line": "Resulta que la idea más potente que existe sobre el dinero se entiende en unos 5 minutos. Aquí tienes la Charla 1."
+    }
   }
 }

--- a/packages/i18n/translations/es/learn.json
+++ b/packages/i18n/translations/es/learn.json
@@ -45,5 +45,16 @@
       "title": "Juntándolo todo",
       "line": "Ya tienes Lo básico."
     }
+  },
+  "quiz": {
+    "title": "Un repaso rápido",
+    "correct": "Esa es.",
+    "incorrect": "Esa no es.",
+    "score": "{count} de {total}",
+    "share": {
+      "button": "Copiar para compartir",
+      "copied": "Copiado",
+      "copyFailed": "No se pudo copiar"
+    }
   }
 }

--- a/packages/i18n/translations/pt-BR/learn-compound-interest.json
+++ b/packages/i18n/translations/pt-BR/learn-compound-interest.json
@@ -82,7 +82,9 @@
       "primaryNote": "Entrar na lista não mexe no seu dinheiro. Você decide depois.",
       "next": "Próximo papo: {title}",
       "waitlist": "Entrar na lista de espera",
-      "secondary": "Mais papos vindo aí"
+      "secondary": "Mais papos vindo aí",
+      "prev": "Voltar pro: {title}",
+      "toolsHub": "Continue com as ferramentas"
     }
   },
   "calculator": {
@@ -113,5 +115,23 @@
     "tableHeaderTotal": "Após {years} anos",
     "loadingState": "Calculando…",
     "calibrationNote": "O que as taxas significam. Os 7% conservadores são o cenário mais estável, os 10% históricos ficam no meio da faixa de longo prazo, e os 14% otimistas são o cenário mais ativo. São cenários, não promessas, e toda taxa tem risco. De forma independente: o S&P 500 rendeu, em média, cerca de 10% ao ano no longo prazo (nominal, com dividendos reinvestidos; cerca de 7% após a inflação), e o ouro cerca de 7% ao ano. No longo prazo, poupar em reais rendeu menos do que manter o dólar digital (números completos nas nossas notas de pesquisa)."
+  },
+  "quiz": {
+    "q1": {
+      "question": "O que torna os juros compostos diferentes de simplesmente poupar?",
+      "options": [
+        "você adiciona dinheiro todo mês",
+        "o crescimento começa a render em cima do próprio crescimento",
+        "o banco garante"
+      ]
+    },
+    "q2": {
+      "question": "O exemplo dos R$ 1.000 para ~R$ 2.252 usou qual taxa?",
+      "options": ["7% cauteloso", "20% garantido", "o que o banco prometer"]
+    },
+    "reflection": "Olha o mês passado e escolhe um gasto pequeno que você não sentiria falta. Sem pressão pra mudar nada. Só repara nele.",
+    "share": {
+      "line": "No fim, a ideia mais poderosa que existe sobre dinheiro leva uns 5 minutos pra entender. Esse é o Papo 1."
+    }
   }
 }

--- a/packages/i18n/translations/pt-BR/learn.json
+++ b/packages/i18n/translations/pt-BR/learn.json
@@ -45,5 +45,16 @@
       "title": "Juntando tudo",
       "line": "Você tem o Básico."
     }
+  },
+  "quiz": {
+    "title": "Bora conferir?",
+    "correct": "É essa mesmo.",
+    "incorrect": "Não é essa.",
+    "score": "{count} de {total}",
+    "share": {
+      "button": "Copiar pra compartilhar",
+      "copied": "Copiado",
+      "copyFailed": "Não deu pra copiar"
+    }
   }
 }

--- a/tests/e2e/learn.spec.ts
+++ b/tests/e2e/learn.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Learn / Real Talk — smoke E2E (Phase 3 Slice A, RV-9).
+ *
+ * Runs against the production build (`pnpm --filter web start`, see
+ * playwright.config.ts webServer) with no external services: the learn pages
+ * read only the registry + i18n, so nothing needs stubbing.
+ *
+ * Assertions are DRIP-STABLE by design: flipping a talk from announced to
+ * live must never break this spec. Counts come from structure (7 arc items),
+ * not from which talks happen to be live this week.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Real Talk index (/en/learn)', () => {
+  test('renders the 7-talk arc with at least one live card and honest announced cards', async ({
+    page,
+  }) => {
+    await page.goto('/en/learn');
+
+    // The arc is an ordered list of 7 talks.
+    const arcItems = page.locator('ol > li');
+    await expect(arcItems).toHaveCount(7);
+
+    // At least one live talk links into /learn/<slug>.
+    const liveLinks = page.locator('ol a[href*="/learn/"]');
+    expect(await liveLinks.count()).toBeGreaterThanOrEqual(1);
+
+    // Announced cards are non-interactive articles (no role, no tabindex),
+    // marked with the availability badge. Adapt this block when all 7 are
+    // live (there will be no announced cards left).
+    const announced = page.locator('[data-status="announced"]');
+    if ((await announced.count()) > 0) {
+      await expect(announced.first()).toContainText(/Coming soon/i);
+      await expect(announced.first()).not.toHaveAttribute('role', /.+/);
+      await expect(announced.first()).not.toHaveAttribute('tabindex', /.+/);
+    }
+  });
+});
+
+test.describe('Talk page (/en/learn/compound-interest)', () => {
+  test('renders the three beats, the quiz, and the education-first CTA group', async ({ page }) => {
+    await page.goto('/en/learn/compound-interest');
+
+    // Three beats by their stable section ids (Phase-0 progress-bar contract).
+    for (const beat of ['beat1', 'beat2', 'beat3']) {
+      await expect(page.locator(`#${beat}`)).toBeAttached();
+    }
+
+    // Quiz: one fieldset per graded question (registry-driven; Talk 1 = 2),
+    // no input elements anywhere in it (the reflection is never a capture).
+    const quiz = page.locator('section[aria-labelledby="talk-quiz-title"]');
+    await expect(quiz).toBeAttached();
+    await expect(quiz.locator('fieldset')).toHaveCount(2);
+    await expect(quiz.locator('input, textarea, select')).toHaveCount(0);
+
+    // Education-first CTA order: the primary anchors back to the tool.
+    await expect(page.locator('a[href="#beat3"]').first()).toBeAttached();
+  });
+
+  test('quiz gives honest feedback and never gates the result', async ({ page }) => {
+    await page.goto('/en/learn/compound-interest');
+
+    const quiz = page.locator('section[aria-labelledby="talk-quiz-title"]');
+    const q1Options = quiz.locator('fieldset').nth(0).locator('button');
+    const q2Options = quiz.locator('fieldset').nth(1).locator('button');
+
+    // Answer both (deliberately one wrong): feedback + score render with no
+    // gate, no retry loop, and the correct answer is revealed.
+    await q1Options.nth(0).click(); // wrong (correct is index 1)
+    await expect(quiz.locator('[data-state="correct"]').first()).toBeAttached();
+    await q2Options.nth(0).click(); // correct
+    await expect(quiz.locator('fieldset').nth(0).locator('button').nth(0)).toBeDisabled();
+  });
+});
+
+test.describe('Announced talk slug', () => {
+  test('shows the 404 UI and leaks no talk content', async ({ page }) => {
+    // Known limitation (Phase-1, founder-accepted): under force-dynamic the
+    // production response is a soft-404 (404 UI over HTTP 200), so this
+    // asserts CONTENT, not status. Drop or adapt when all 7 talks are live.
+    await page.goto('/en/learn/money-objective');
+    await expect(page.locator('#beat1')).not.toBeAttached();
+    await expect(page.locator('section[aria-labelledby="talk-quiz-title"]')).not.toBeAttached();
+  });
+});


### PR DESCRIPTION
## What

Slice A of Phase 3 (`docs/learn/30-day-series/PHASE3_IMPLEMENTATION_SPEC.md`, §1–3): the user-visible half. Slice B (VideoFacade + CSP, ships dark) follows as a stacked PR.

- **TalkQuiz** (Factory + `TalkQuizDefault`): 2 graded questions + ungraded reflection + copy-to-share, placed after the beat-3 wrap and before the CTA group (the LESSON_COMPLETED sentinel keeps meaning "reached the end"). Correctness lives in the registry (`blocks.quiz.correctIndexes = [1, 0]`, RV-4: one source of truth across locales; a translation typo can never flip an answer); options read with the until-exhausted array pattern.
- **Talk-1 quiz content ×4 verbatim** from the approved talk files (founder-approved copy). **Two documented deviations:** (1) no `explain` lines — the approved files carry none, and shipping self-drafted teaching copy would break the verbatim rule; feedback = chrome correct/incorrect + the correct option revealed; (2) Q2's "$1,000 → ~$2,252" glyph arrow adapted to "to"/"para"/"a"/"zu" (anti-slop Part-2 glyph rule) — [NPR] on these four minimal adaptations.
- **Spine completion**: prev-talk link (drip-gated via new `getPrevLiveLesson`, mirror of next) + the Talk-7 terminal branch → `/tools` (**D-P3-1**: the "more talks are on the way" fallback would be false once the series completes). Registry-derived, correct in every drip state.
- **Waitlist attribution (RV-2)**: `setCtaSource('learn-<lessonId>')` through the existing sessionStorage machinery (mirrors DemoLauncher) — zero waitlist-code changes; lands as `cta_source:learn-compound-interest` tag + event param. Verified chain: rendered `/en#waitlist` href, home anchor exists ×4 compositions, sessionStorage survives the client-side navigation.
- **New stable wire names**: `learn_quiz_submitted` `{lessonId, locale, correctCount}` (aggregate only, never per-question answers), `learn_share_copied`; `learn_cta_secondary_clicked` gains `prev-talk`/`tools` targets.
- **Chrome strings ×4** (`learn.quiz.*` shared; `beat3.cta.prev/toolsHub` per-talk) — the only new copy, [NATIVE PASS REQUIRED].

## Tests + commands

10 TalkQuiz RTL tests (feedback both ways, single aggregate event with correctCount permutations 0/1/2, clipboard success+failure, analytics-off silence, no-quiz Factory null) · `getPrevLiveLesson` permutations · two-way quiz drift guards (registry ↔ en keys; correctIndex bounds vs en option counts) · **e2e `learn.spec.ts`** (RV-9, drip-stable by design: arc structure, talk page + quiz, honest feedback, announced-slug no-leak) — 4/4 + the existing waitlist e2e still green.

type-check ✓ · lint 0 errors ✓ · **1303 vitest / 109 files** ✓ · build ✓ · e2e 5/5 ✓ · format:check ✓ · validate:translations (34×4) ✓ · validate:ux-canon ✓ · knip ✓ · dev smoke ✓ (quiz renders, announced slug real 404) · `next start` smoke **11/11** ×4 locales (verbatim quiz strings, no inputs in the quiz zone, CTA order intact, no prev/toolsHub leakage on Talk 1).

Verbatim audit: every quiz string grep-verified against the approved files (q2 via the documented adaptation mapping); added i18n lines em-dash-free and glyph-free.

## Gates

- **Anti-slop rows cited**: 10 (no urgency), 12 (no badges/gamification — score is a plain "{count} of {total}" line), **15 inverse by design** (nothing gated: feedback, score, and share render regardless of answers), 16 (buttons say what they do: "Copy to share" → "Copied"), 19 (states are real: correct/incorrect/muted reflect actual answers).
- **Voice Q1–Q4**: quiz content is approved copy; chrome is peer register per locale ("Bora conferir?" / "Kurz nachgehakt"); **Q3 PASS** — the reflection explicitly never becomes a directive or a capture (no input element, asserted in unit + e2e tests).
- **Storytelling**: retrieval practice as C5 earned payoff; the share line is the approved "a result, never share-to-unlock" framing.
- **12 principles**: correctness = domain (registry) vs display = presentation (i18n); stable event taxonomy; DRY (attribution reuses ctaAttribution; no TalkSpine component per RV-1); ~160-line component; clipboard try/catch + quiet failure; no new input surfaces or PII; ref-stored timers cleared on unmount.

## Disclosures

- Measured completion rate may dip when this ships: the quiz lengthens the page above the LESSON_COMPLETED sentinel. Definition unchanged.
- The prev-talk and Talk-7 render branches cannot render on Talk 1 (helper logic is permutation-tested); they join the next-talk branch on the **Phase-4 go-live smoke checklist**.
- Known-broken "Dependency vulnerability audit" CI check: npm retired the endpoint; unrelated.

## [NATIVE PASS REQUIRED]
Chrome strings ×3 non-EN locales + the four q2 glyph-arrow adaptations, one batch (founder = pt-BR; ES/DE native check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)