### PR TITLE
fix(ci): stop the retired npm audit endpoint from failing every PR

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,7 +56,27 @@ jobs:
           #
           # Baseline post-override: 4 moderate / 0 high. Update this list when
           # the override resolves or a new transitive HIGH appears.
-          pnpm audit --prod --audit-level=critical || echo "failed=true" >> $GITHUB_OUTPUT
+          #
+          # 2026-07-16: npm RETIRED the audit endpoints pnpm 10.33 calls
+          # (HTTP 410 on both /audits/quick and /audits; ERR_PNPM_AUDIT_BAD_RESPONSE),
+          # which reddened every PR with an infrastructure error, not a finding.
+          # Distinguish the two: the endpoint outage is a warning (dependency
+          # scanning remains covered by the Snyk PR checks + the quarterly
+          # security-scan workflow); anything else that fails the audit still
+          # fails the job. Remove the ERR_PNPM_AUDIT_BAD_RESPONSE branch when
+          # pnpm ships the bulk-advisory-endpoint fix.
+          set +e
+          OUTPUT=$(pnpm audit --prod --audit-level=critical 2>&1)
+          CODE=$?
+          set -e
+          echo "$OUTPUT"
+          if [ $CODE -ne 0 ]; then
+            if echo "$OUTPUT" | grep -q "ERR_PNPM_AUDIT_BAD_RESPONSE"; then
+              echo "::warning title=npm audit endpoint retired::pnpm audit hit the retired npm endpoint (HTTP 410). Treated as infrastructure outage, not a vulnerability finding. Coverage continues via Snyk PR checks + the quarterly scan."
+            else
+              echo "failed=true" >> $GITHUB_OUTPUT
+            fi
+          fi
         continue-on-error: true
 
       - name: Notify Slack on Failure


### PR DESCRIPTION
npm retired the audit endpoints pnpm 10.33 calls (HTTP 410 on both
/audits/quick and /audits since 2026-07-15; ERR_PNPM_AUDIT_BAD_RESPONSE).
The job treated the infrastructure error as a vulnerability finding and
reddened every PR. Now: that specific error becomes a workflow warning
(dependency scanning remains covered by the Snyk PR checks + the
quarterly security-scan workflow); any other audit failure still fails
the job. Remove the branch when pnpm ships the bulk-endpoint fix.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
