### PR TITLE
fix(learn): render the approved *repeat* emphasis in vignettesIntro (V-4)

### DIFF
--- a/apps/web/src/components/Sections/Lesson/variants/LessonThreeBeat/LessonThreeBeat.tsx
+++ b/apps/web/src/components/Sections/Lesson/variants/LessonThreeBeat/LessonThreeBeat.tsx
@@ -262,7 +262,13 @@ export function LessonThreeBeat({
             {showVignettes && (
               <>
                 <p className={styles.habitsLine}>{t('beat2.habitsLine')}</p>
-                <p className={styles.beatBody}>{t('beat2.vignettesIntro')}</p>
+                <p
+                  className={styles.beatBody}
+                  // V-4 (visual pass, 2026-07-16): this string carries the
+                  // approved *repeat* emphasis; without the helper the
+                  // asterisks rendered literally in all 4 locales.
+                  dangerouslySetInnerHTML={renderInlineEmphasis(t('beat2.vignettesIntro'))}
+                />
                 <CalculatorVignettes />
                 <DisclaimerNote variant="projection">
                   {t('beat2.vignettesDisclaimer')}


### PR DESCRIPTION
The full-program visual re-validation caught literal asterisks on the
live page in all 4 locales: beat2.vignettesIntro carries the approved
*repeat* / *repetem* / *repiten* / *wiederholen* emphasis, but was the
one emphasis-bearing string rendered without renderInlineEmphasis
(escape-first helper; beat1 body + beat2 intro already use it). Swept
all learn-compound-interest keys x4: no other unhandled emphasis.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
