### PR TITLE
fix(quality): harden validate:seo (mutation audit) + doc currency sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,10 @@ pnpm build            # Production build (all workspaces)
 ### Validation
 
 ```bash
-pnpm validate:all              # Full pipeline: type-check -> lint -> test -> build -> budget -> design-tokens -> translations -> market-data -> sdk-invariant -> investor-figures -> ux-canon
+pnpm validate:all              # Full pipeline: type-check -> lint -> test -> build -> budget -> design-tokens -> translations -> market-data -> sdk-invariant -> investor-figures -> seo -> ux-canon
 pnpm validate:design-tokens    # Validate design tokens against schema
 pnpm validate:translations     # Check translation key parity across locales
+pnpm validate:seo              # SEO gate: config bounds/uniqueness, route/OG parity, per-locale seo keys
 pnpm check:dead-code           # Dead code detection (knip)
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ flowchart TD
   end
 
   subgraph Packages["Monorepo packages (Turborepo + pnpm)"]
-    I18N["@diboas/i18n<br/>34 namespaces × 4 locales (lazy)"]
+    I18N["@diboas/i18n<br/>40 namespaces × 4 locales (lazy)"]
     UI["@diboas/ui — design system"]
     EMAIL["@diboas/email — Resend + retry/backoff"]
   end
@@ -65,7 +65,7 @@ flowchart TD
 
 - **Testing & CI:** strict TypeScript, ~1,222 automated tests (Vitest), Lighthouse CI + pa11y (WCAG 2.1 AA), and 6 GitHub Actions workflows (CI, security audit, accessibility, E2E, Lighthouse, quarterly security scan) plus a weekly /market data-refresh workflow.
 - **Security:** per-request **nonce-based CSP** (`'unsafe-inline'` prohibited for scripts), **AES-256-GCM** encryption for PII at rest, **HMAC blind indexing**, Upstash rate limiting, DOMPurify sanitization, and CSRF protection on mutation endpoints.
-- **i18n:** 34 namespaces × 4 locales, lazy-loaded per locale × namespace, drift-guarded by a parity test.
+- **i18n:** 40 namespaces × 4 locales, lazy-loaded per locale × namespace, drift-guarded by a parity test.
 - **Monitoring:** Sentry, PostHog, and GA4 — all consent-gated and lazy-loaded behind a cookie-consent check.
 
 > **Product architecture is Phase 2+, not in this build.** The money product's design — non-custodial by design (users hold their own funds; diBoaS holds no key shares, and recovery runs through an integrated third-party provider), MPC wallets (Turnkey), multi-chain DeFi (stable strategies on Arbitrum, growth on Solana) — is roadmap. Those decisions live in [`CLAUDE.md`](./CLAUDE.md); the full technical write-up for reviewers belongs in the investor room's technical-architecture summary.

--- a/docs/tech/coding-standards.md
+++ b/docs/tech/coding-standards.md
@@ -1,5 +1,7 @@
 # Coding Standards & Best Practices
 
+> **Enforcement:** every principle below maps to its LIVE enforcement (CI job, lint rule, drift-guard test, or mandatory review checklist) in `docs/tech/engineering-gates.md`; resilience rows to cite in PRs live in `docs/tech/robustness-checklist.md`.
+
 > **The 12 Principles of Excellence for building robust, maintainable fintech applications**
 
 **Note:** These principles apply across all phases. Examples use Phase 2+ domain names (Banking, Investing, DeFi) for illustration. In Phase 1 (pre-launch), apply the same patterns to the waitlist, marketing, and i18n domains. See CLAUDE.md for the canonical Phase 1 implementation reference.

--- a/docs/tech/internationalization.md
+++ b/docs/tech/internationalization.md
@@ -8,7 +8,7 @@
 
 The platform supports **4 locales** — English (`en`, reference/source of truth), Brazilian Portuguese (`pt-BR`), Spanish (`es`), German (`de`) — with automatic browser-language detection and a reusable, config-driven translation system.
 
-- **Canonical namespace inventory** (currently **34 namespaces per locale** — the investor vertical added `investor` + `investor-docs`) + the Phase-7 Q4 banned-term grep gate: **`packages/i18n/README.md`**.
+- **Canonical namespace inventory** (currently **40 namespaces per locale** — most recently the 6 Real Talk talk namespaces (`learn-*`, Phase 4 2026-07-16)) + the Phase-7 Q4 banned-term grep gate: **`packages/i18n/README.md`**.
 - **Translation files:** `packages/i18n/translations/{en,pt-BR,es,de}/<namespace>.json` (+ `legal/` subdirectory).
 - **Parity enforcement:** `pnpm validate:translations` (`scripts/validate-translations.js`) checks key parity across all 4 locales — required before any PR that touches copy.
 - **All new user-facing strings must be added to all 4 locales.** German text runs ~30% longer than English — verify components handle expansion.

--- a/docs/tech/robustness-checklist.md
+++ b/docs/tech/robustness-checklist.md
@@ -26,6 +26,7 @@
 | R-12 | Cross-origin embeds (iframes) never rely on `onError`; detection uses load-timeout heuristics, and an always-present honest fallback link exists regardless of detection                                | Undetectable blocked embeds; ad-blocker dead-ends                 |
 | R-13 | Every error path is TESTED per the testing policy (error handlers, rejected promises, failure branches) — a fallback that has never run in a test does not exist                                        | Fallbacks that crash when finally exercised                       |
 | R-14 | Failures are observable: errors reach Sentry through the single-coordinator pattern (never a second global handler); background jobs fail closed, not silent                                            | Invisible breakage; competing error handlers                      |
+| R-15 | Every route group ships a `loading.tsx` (Suspense shell) and async sections show explicit loading states — no blank flash while data resolves                                                           | Perceived crashes; CLS regressions on slow networks               |
 
 ## How to cite
 

--- a/scripts/validate-seo.mjs
+++ b/scripts/validate-seo.mjs
@@ -120,8 +120,20 @@ while ((m = talkRe.exec(registry))) {
 
 // ---------- OG parity ----------
 const og = read('apps/web/src/lib/og/templates.tsx');
-const ogKeys = [...og.matchAll(/^  '?([a-z-]+)'?: \{\s*\n\s*title:/gm)].map((x) => x[1]);
-const validBlock = og.slice(og.indexOf('function isValidPageType'));
+// Parse the WHOLE PAGE_CONFIGS block (comment-robust: keys may have comment
+// lines between the key and its first prop).
+const cfgStart = og.indexOf('PAGE_CONFIGS');
+const cfgBlock = og.slice(cfgStart, og.indexOf('} as const', cfgStart));
+const ogKeys = [...cfgBlock.matchAll(/^  '?([a-z][a-z0-9-]*)'?: \{/gm)].map((x) => x[1]);
+if (ogKeys.length < 20)
+  errors.push(
+    `parser sanity: only ${ogKeys.length} OG PAGE_CONFIGS keys parsed (expected 20+) — source format changed; update this script`
+  );
+// Bound the allowlist to the array literal and STRIP COMMENTS before
+// matching — a comment mentioning a key must never satisfy the check
+// (mutation-audit finding, 2026-07-17).
+const fnStart = og.indexOf('function isValidPageType');
+const validBlock = og.slice(fnStart, og.indexOf('].includes', fnStart)).replace(/\/\/[^\n]*/g, '');
 for (const k of ogKeys) {
   if (!validBlock.includes(`'${k}'`))
     errors.push(


### PR DESCRIPTION
- MUTATION AUDIT on the new gate (4 adversarial mutations): 3 fired, 1
  was SILENT - a code comment mentioning 'learn' inside isValidPageType
  satisfied the OG parity check even with the entry removed. Fixed:
  the allowlist is bounded to the array literal and COMMENT-STRIPPED
  before matching; the PAGE_CONFIGS parser now reads the whole block
  (comment-robust, 22/22 keys vs 20 before) with its own sanity floor.
  All 4 mutations now fire; gate re-verified green
- R-15 added to the robustness checklist (loading.tsx/Suspense shells -
  the one CLAUDE.md error-handling prose rule without a row)
- Doc currency sweep (founder request): CLAUDE.md validate:all pipeline
  line + validate:seo command listed; README + internationalization.md
  34->40 namespace counts (missed spots); coding-standards.md now points
  to engineering-gates.md + the R-rows (the 12 principles doc itself
  says where each principle is enforced)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
