### PR TITLE
ci(market): format-check pipeline-written files before opening the weekly PR (B4b)

### DIFF
--- a/.github/workflows/market-refresh-weekly.yml
+++ b/.github/workflows/market-refresh-weekly.yml
@@ -68,6 +68,14 @@ jobs:
           node scripts/check-market-data-jargon.mjs
           pnpm --filter web exec vitest run src/lib/market-data
 
+      # B4(b) 2026-08-11: bot-created PRs (GITHUB_TOKEN) never trigger the main
+      # CI, so its format:check does not run on the weekly PR — a formatting
+      # violation in pipeline-written files would only surface when a human
+      # pushed to the branch (hit 2026-08-11 on the manual data-status edit).
+      # Check every file the pipeline writes before opening the PR.
+      - name: Format check on pipeline-written files
+        run: pnpm exec prettier --check "apps/web/data/market/**/*.json" "apps/web/src/lib/market-data/data/*.json"
+
       - name: Open refresh PR
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
## What

B4(b) from the market/data workstream plan: the weekly refresh workflow now runs a scoped **prettier check on every file the pipeline writes** (`apps/web/data/market/**/*.json` + `apps/web/src/lib/market-data/data/*.json`) before opening the bot PR.

## Why

PRs created with `GITHUB_TOKEN` never trigger `on: pull_request` workflows, so the main CI's `format:check` does not run on the weekly bot PR — a formatting violation would only surface when a human pushed to the branch (exactly what happened 2026-08-11 with a hand-edited `data-status.json`). The workflow already ran the drift check (`generate.mjs --check`), the jargon gate, and the full market vitest pre-PR — the format gate was the one missing piece. This closes the gap without needing a PAT; B4(a) (the `MARKET_REFRESH_PR_TOKEN` secret for full CI on bot PRs) remains open as a founder action.

## Verification

- Workflow YAML validated (parser) and the exact prettier command dry-run locally against the current tree: clean.
- Single additive step; no change to the pipeline stages, PR body, or permissions.
- Caveat stated honestly: a workflow edit is only fully proven when it fires — `workflow_dispatch` is available for a manual pre-Monday test run if desired.

## Gates

No runtime surface, no user-facing copy, no data change — anti-slop Part 3 / voice rubric N/A; R-rows N/A (CI-only additive step); 12-principles: #7/#12 (a fail-loud gate where there was silence), #8 (defense in depth on the automated write path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)