### PR TITLE
ci(market): weekly PR via MARKET_REFRESH_PR_TOKEN — full CI on the bot PR (B4a)

### DIFF
--- a/.github/workflows/market-refresh-weekly.yml
+++ b/.github/workflows/market-refresh-weekly.yml
@@ -79,6 +79,13 @@ jobs:
       - name: Open refresh PR
         uses: peter-evans/create-pull-request@v7
         with:
+          # B4(a) 2026-08-11: a PR created with the default GITHUB_TOKEN never
+          # triggers `pull_request` workflows, so the weekly PR got no main CI.
+          # The fine-grained PAT (Contents + Pull requests on this repo only,
+          # founder-owned) makes the full battery run on it. Falls back to the
+          # default token (old no-CI behavior, still guarded by the in-workflow
+          # gates) if the secret is removed or expires.
+          token: ${{ secrets.MARKET_REFRESH_PR_TOKEN || github.token }}
           branch: editorial/market-refresh-auto
           commit-message: 'data(market): weekly refresh (automated)'
           title: 'data(market): weekly refresh — review before merge'


### PR DESCRIPTION
## What

B4(a), the final Part B item: the weekly refresh workflow now creates its PR with the founder-created fine-grained PAT (`MARKET_REFRESH_PR_TOKEN` — Contents + Pull requests, this repo only), so the weekly PR triggers the **full `pull_request` CI battery** (quality, e2e, lighthouse, pa11y, gitleaks, dependency audit) instead of only Vercel/Snyk.

- `token: ${{ secrets.MARKET_REFRESH_PR_TOKEN || github.token }}` — if the secret is ever removed or expires, the workflow falls back to the default token (today's no-CI behavior) instead of failing; the B4(b) in-workflow gates (drift check, jargon, market vitest, format check) still guard that fallback path.
- Known cosmetic effect: the weekly PR's author becomes the token owner instead of `github-actions[bot]`. No behavioral impact under current branch rules (no required-approvals rule on `main`).
- Token expiry degrades loudly: an invalid token fails the PR-creation step → workflow-failure email.

## Verification

- YAML validated (parser) + prettier clean. Single additive input on the create-pull-request step; no pipeline-stage changes.
- Honest caveat, same as B4(b): a workflow edit is fully proven only when it fires — first live proof is Monday's 06:00 UTC run (or a `workflow_dispatch` test).

## Gates

CI-only change, no runtime surface, no copy, no data — anti-slop/voice/R-rows N/A; 12-principles: #7 (graceful fallback), #8/#12 (full CI on the automated write path = defense in depth + observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)