### PR TITLE
fix(dead-code): sandbox knip green — dormant client.ts ignore + docblock pragma false-positive (5.74)

### DIFF
--- a/apps/sandbox/src/test/setup.ts
+++ b/apps/sandbox/src/test/setup.ts
@@ -2,7 +2,10 @@
  * Sandbox test setup (sandbox-specific — apps/web/src/test/setup.ts is
  * web-specific and deliberately not copied; see CLAUDE.md § Testing).
  *
- * Component tests annotate `// @vitest-environment happy-dom` per file;
+ * Component tests opt into the DOM via vitest's per-file happy-dom
+ * environment pragma (see BottomSheet.test.tsx line 1 for the form — the
+ * literal tag is not written here because knip parses leading doc comments
+ * for it and would demand a vitest-environment-* package);
  * cleanup only runs where a DOM exists.
  */
 import { afterEach } from 'vitest';

--- a/knip.json
+++ b/knip.json
@@ -47,6 +47,9 @@
     },
     "packages/email": {
       "project": ["src/**/*.{ts,tsx}"]
+    },
+    "apps/sandbox": {
+      "ignore": ["src/lib/database/client.ts"]
     }
   }
 }


### PR DESCRIPTION
Unblocks the repo-wide dead-code gate (RED on main since the sandbox harness landed — PENDING_ALL 5.74, relayed by the market session 2026-08-11).

- **(a)** `apps/sandbox/src/lib/database/client.ts` → knip `ignore` entry: **dormant-by-design P1.2 scaffolding** awaiting its Phase A/B Neon consumers per the R1 plan (the `lib/waitingList/domain/**` precedent; importer trace confirmed zero non-test consumers; never-delete-on-report rule honored).
- **(b)** the `vitest-environment-happy-dom` "unlisted dependency" was a knip **false positive**: it parses the setup.ts leading doc-comment *mention* of the `@vitest-environment` pragma as a real directive. Reworded the comment — **zero dependency/lockfile changes** (better than declaring a package that doesn't exist on npm).

Verified: `pnpm check:dead-code` GREEN · sandbox suite 52/52 · prettier clean. No shared-file channels touched (no lockfile, no package.json, no turbo.json).

Robustness self-check: no effects/timers/listeners/async paths touched (config + comment only) — R-rows N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)