### PR TITLE
feat(market): M1 identity re-scope — Adelaide Market becomes multi-market (Market Macro)

### DIFF
--- a/packages/i18n/translations/de/market.json
+++ b/packages/i18n/translations/de/market.json
@@ -1,14 +1,14 @@
 {
   "seo": {
     "title": "Adelaide Market",
-    "description": "Ruhige Makro-Intelligenz für Bitcoin. Verstehe das Umfeld, nicht die nächste Kerze.",
+    "description": "Ruhige Makro-Intelligenz für die Finanzmärkte, beginnend mit Bitcoin. Verstehe das Umfeld, nicht die nächste Kerze.",
     "ogTitle": "Adelaide Market",
-    "ogDescription": "Ruhige Makro-Intelligenz für Bitcoin. Verstehe das Umfeld, nicht die nächste Kerze."
+    "ogDescription": "Ruhige Makro-Intelligenz für die Finanzmärkte, beginnend mit Bitcoin. Verstehe das Umfeld, nicht die nächste Kerze."
   },
   "hero": {
     "title": "Adelaide Market",
-    "subtitle": "Ruhige Makro-Intelligenz für Bitcoin.",
-    "kicker": "Makro-Umfeld-Score"
+    "subtitle": "Ruhige Makro-Intelligenz für die Finanzmärkte.",
+    "kicker": "Bitcoin-Makro-Umfeld-Score"
   },
   "dashboard": {
     "scoreAriaLabel": "Aktueller Makro-Umfeld-Score",
@@ -64,7 +64,7 @@
     "waitlist": "Der Warteliste beitreten",
     "share": "Teilen",
     "shareCopied": "Link kopiert",
-    "shareText": "Adelaide Market: ruhige Makro-Einordnung für Bitcoin."
+    "shareText": "Adelaide Market: ruhige Makro-Einordnung für die Finanzmärkte."
   },
   "fallback": {
     "outageTitle": "Live-Daten vorübergehend nicht verfügbar",

--- a/packages/i18n/translations/en/market.json
+++ b/packages/i18n/translations/en/market.json
@@ -1,14 +1,14 @@
 {
   "seo": {
     "title": "Adelaide Market",
-    "description": "A calm read on Bitcoin. Understand the environment, not the next price move.",
+    "description": "A calm read on the financial markets, starting with Bitcoin. Understand the environment, not the next price move.",
     "ogTitle": "Adelaide Market",
-    "ogDescription": "A calm read on Bitcoin. Understand the environment, not the next price move."
+    "ogDescription": "A calm read on the financial markets, starting with Bitcoin. Understand the environment, not the next price move."
   },
   "hero": {
     "title": "Adelaide Market",
-    "subtitle": "A calm read on Bitcoin, without the noise.",
-    "kicker": "Macro environment score"
+    "subtitle": "A calm read on the financial markets, without the noise.",
+    "kicker": "Bitcoin macro environment score"
   },
   "dashboard": {
     "scoreAriaLabel": "Current macro environment score",
@@ -64,7 +64,7 @@
     "waitlist": "Join the waitlist",
     "share": "Share",
     "shareCopied": "Link copied",
-    "shareText": "Adelaide Market: calm macro intelligence for Bitcoin."
+    "shareText": "Adelaide Market: calm macro intelligence for the financial markets."
   },
   "fallback": {
     "outageTitle": "Live data is temporarily unavailable",

--- a/packages/i18n/translations/es/market.json
+++ b/packages/i18n/translations/es/market.json
@@ -1,14 +1,14 @@
 {
   "seo": {
     "title": "Adelaide Market",
-    "description": "Inteligencia macro serena para Bitcoin. Entiende el entorno, no la próxima vela.",
+    "description": "Inteligencia macro serena para los mercados financieros, empezando por Bitcoin. Entiende el entorno, no la próxima vela.",
     "ogTitle": "Adelaide Market",
-    "ogDescription": "Inteligencia macro serena para Bitcoin. Entiende el entorno, no la próxima vela."
+    "ogDescription": "Inteligencia macro serena para los mercados financieros, empezando por Bitcoin. Entiende el entorno, no la próxima vela."
   },
   "hero": {
     "title": "Adelaide Market",
-    "subtitle": "Inteligencia macro serena para Bitcoin.",
-    "kicker": "Score del entorno macro"
+    "subtitle": "Inteligencia macro serena para los mercados financieros.",
+    "kicker": "Score del entorno macro de Bitcoin"
   },
   "dashboard": {
     "scoreAriaLabel": "Score actual del entorno macro",
@@ -64,7 +64,7 @@
     "waitlist": "Unirme a la lista de espera",
     "share": "Compartir",
     "shareCopied": "Enlace copiado",
-    "shareText": "Adelaide Market: inteligencia macro calmada para Bitcoin."
+    "shareText": "Adelaide Market: inteligencia macro calmada para los mercados financieros."
   },
   "fallback": {
     "outageTitle": "Datos en vivo temporalmente no disponibles",

--- a/packages/i18n/translations/pt-BR/market.json
+++ b/packages/i18n/translations/pt-BR/market.json
@@ -1,14 +1,14 @@
 {
   "seo": {
     "title": "Adelaide Market",
-    "description": "Inteligência macro serena para Bitcoin. Entenda o ambiente, não o próximo candle.",
+    "description": "Inteligência macro serena para os mercados financeiros, começando pelo Bitcoin. Entenda o ambiente, não o próximo candle.",
     "ogTitle": "Adelaide Market",
-    "ogDescription": "Inteligência macro serena para Bitcoin. Entenda o ambiente, não o próximo candle."
+    "ogDescription": "Inteligência macro serena para os mercados financeiros, começando pelo Bitcoin. Entenda o ambiente, não o próximo candle."
   },
   "hero": {
     "title": "Adelaide Market",
-    "subtitle": "Inteligência macro serena para Bitcoin.",
-    "kicker": "Score do ambiente macro"
+    "subtitle": "Inteligência macro serena para os mercados financeiros.",
+    "kicker": "Score do ambiente macro do Bitcoin"
   },
   "dashboard": {
     "scoreAriaLabel": "Score atual do ambiente macro",
@@ -64,7 +64,7 @@
     "waitlist": "Entrar na lista de espera",
     "share": "Compartilhar",
     "shareCopied": "Link copiado",
-    "shareText": "Adelaide Market: inteligência macro calma para Bitcoin."
+    "shareText": "Adelaide Market: inteligência macro calma para os mercados financeiros."
   },
   "fallback": {
     "outageTitle": "Dados ao vivo temporariamente indisponíveis",


### PR DESCRIPTION
## What

**M1 of the Market Macro program** (founder-ratified 2026-08-12, all five MM decisions ruled): `/market`'s identity re-scopes from Bitcoin-only to the financial markets. **i18n-only** — 5 strings × 4 locales:

| Key | EN (new) |
|---|---|
| `hero.subtitle` | "A calm read on the financial markets, without the noise." |
| `hero.kicker` | "Bitcoin macro environment score" — the chip now carries the per-view label, so the multi-market identity never overpromises while BTC is the only live view |
| `seo.description` / `ogDescription` | "A calm read on the financial markets, starting with Bitcoin. Understand the environment, not the next price move." |
| `cta.shareText` | "Adelaide Market: calm macro intelligence for the financial markets." |

pt-BR / es / de follow their established per-locale voice ("Inteligência macro serena…", "Inteligencia macro serena…", "Ruhige Makro-Intelligenz…" — du-register preserved).

**Deliberately unchanged:** "Adelaide Market" (brand name), the host regulatory disclaimer (" …for Bitcoin" stays *accurate* until the first non-BTC view ships — re-scope gated to M3), `dashboard.sources.*` (they label actual BTC data feeds), and `methodology.json#framework_name` (MM-1: "diBoaS Bitcoin Environment Framework" survives scoped to the Bitcoin view).

## Program context

Rulings recorded in `MARKET_MACRO_PROGRAM_2026-08-12.md` + drift-log **D6**: tier map (macro backdrop, gold, umbrella → DeFi Macro, stablecoin health → equities, ETH), MM-2 score grammar (five band words = family-wide shared grammar; numeric score = per-market supporting detail; health views = qualitative states; **R-4 anti-ranking: the umbrella view never orders markets by score**), R-1 stablecoin view no-CLO with the no-APY boundary. `MARKET_INDEXABLE` stays off pending the post-M1 translator pass (MM-4).

## Gates

- `validate:translations` ✓ 4-locale parity · `validate:seo` ✓ (bounds/uniqueness/em-dash ban — no em-dashes in the new seo strings) · 237 market tests ✓
- **Voice rubric:** Q1 calm PASS · Q2 Adelaide PASS · **Q3 PASS** (observational identity copy; "starting with Bitcoin" is a factual statement, not a promise of specific future markets) · Q4 PASS. Non-EN in-register (pt-BR neutral-formal, es peninsular, de du) — engineering-drafted per the established market.json convention; the professional pass rides MM-4's scheduled translator gate.
- **Anti-slop Part 3:** copy rows clean (no urgency, no fabrication, honest scope labeling — the kicker label is the anti-overpromise rider); veto rows 10–17 PASS/N-A.
- **R-rows:** N/A (strings only).
- Visual pass on the preview (4 locales, the hero chip + strapline) follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)