### PR TITLE
data(protocols): TVL refresh hotfix — combined $120B → $25B (90-day guard, pre-Monday deadline)

### DIFF
--- a/apps/web/src/lib/market-data/constants.ts
+++ b/apps/web/src/lib/market-data/constants.ts
@@ -294,9 +294,13 @@ export const FALLBACK_MARKET_DATA: MarketDataSnapshot = {
   // manual until iter-5 SDK swap delivers daily via DeFiLlama-equivalent.
   protocolData: {
     tvl: {
-      combined: '$120 billion',
+      // 2026-08-13 refresh (DeFiLlama parent aggregates, monthly-refresh
+      // discipline): Aave $14.8B + Sky $5.8B + Jupiter $1.5B + Sanctum $1.3B
+      // + Compound $1.2B + Jito $0.8B = $25.4B -> "over $25 billion".
+      // The previous $120B was the pre-drawdown February figure.
+      combined: '$25 billion',
     },
-    updatedAt: '2026-05-15T00:00:00Z',
+    updatedAt: '2026-08-13T00:00:00Z',
   },
   metadata: {
     fetchedAt: '2026-03-15T00:00:00Z',

--- a/packages/i18n/translations/de/protocols.json
+++ b/packages/i18n/translations/de/protocols.json
@@ -370,10 +370,10 @@
   "tvl": {
     "h2": "Gemeinsam gesicherter Wert",
     "textBefore": "Die Protokolle auf dieser Seite halten zusammen über",
-    "number": "120 Milliarden USD",
+    "number": "25 Milliarden USD",
     "textAfter": "an Nutzereinlagen über alle ihre Deployments. Das ist echtes Geld, von echten Menschen, das bereits in diesen Systemen steckt.",
     "context": "Das bedeutet nicht, dass dein Geld in allen steckt. Jede diBoaS-Strategie nutzt bestimmte Protokolle, die zu ihrem Risikoniveau und ihren Zielen passen. Auf der Strategieseite siehst du, welche Protokolle in welcher Strategie eingesetzt werden.",
-    "source": "Gesamt-TVL von DeFiLlama. Letzte Überprüfung: Februar 2026. Die Werte schwanken täglich."
+    "source": "Gesamt-TVL von DeFiLlama. Letzte Überprüfung: August 2026. Die Werte schwanken täglich."
   },
   "notIs": {
     "h2": "Achtung",

--- a/packages/i18n/translations/en/protocols.json
+++ b/packages/i18n/translations/en/protocols.json
@@ -370,10 +370,10 @@
   "tvl": {
     "h2": "Combined Value Secured",
     "textBefore": "The protocols on this page collectively hold over",
-    "number": "$120 billion",
+    "number": "$25 billion",
     "textAfter": "in user deposits across all their deployments. That is real money, from real people, already in these systems.",
     "context": "This does not mean your money is in all of them. Each diBoaS strategy uses specific protocols suited to its risk level and goals. See the Strategies page for which protocols are used in which strategy.",
-    "source": "Combined TVL sourced from DeFiLlama. Last verified: February 2026. Values fluctuate daily."
+    "source": "Combined TVL sourced from DeFiLlama. Last verified: August 2026. Values fluctuate daily."
   },
   "notIs": {
     "h2": "Attention",

--- a/packages/i18n/translations/es/protocols.json
+++ b/packages/i18n/translations/es/protocols.json
@@ -370,10 +370,10 @@
   "tvl": {
     "h2": "Valor combinado asegurado",
     "textBefore": "Los protocolos en esta página mantienen colectivamente más de",
-    "number": "120.000 millones USD",
+    "number": "25.000 millones USD",
     "textAfter": "en depósitos de usuarios a través de todos sus despliegues. Es dinero real, de gente real, ya dentro de estos sistemas.",
     "context": "Esto no significa que tu dinero esté en todos ellos. Cada estrategia de diBoaS usa protocolos específicos adecuados a su nivel de riesgo y objetivos. Consulta la página de Estrategias para ver qué protocolos se usan en cada estrategia.",
-    "source": "TVL combinado obtenido de DeFiLlama. Última verificación: febrero de 2026. Los valores fluctúan diariamente."
+    "source": "TVL combinado obtenido de DeFiLlama. Última verificación: agosto de 2026. Los valores fluctúan diariamente."
   },
   "notIs": {
     "h2": "Atención",

--- a/packages/i18n/translations/pt-BR/protocols.json
+++ b/packages/i18n/translations/pt-BR/protocols.json
@@ -370,10 +370,10 @@
   "tvl": {
     "h2": "Valor combinado protegido",
     "textBefore": "Os protocolos nessa página mantêm juntos mais de",
-    "number": "US$120 bilhões",
+    "number": "US$25 bilhões",
     "textAfter": "em depósitos de usuários nas redes onde operam. É dinheiro de verdade, de pessoas de verdade, já dentro desses sistemas.",
     "context": "Isso não significa que seu dinheiro está em todos eles. Cada estratégia do diBoaS usa protocolos específicos adequados ao seu nível de risco e objetivos. Veja a página de Estratégias pra saber quais protocolos são usados em cada estratégia.",
-    "source": "TVL combinado obtido do DeFiLlama. Última verificação: fevereiro de 2026. Os valores variam diariamente."
+    "source": "TVL combinado obtido do DeFiLlama. Última verificação: agosto de 2026. Os valores variam diariamente."
   },
   "notIs": {
     "h2": "Atenção",


### PR DESCRIPTION
Cherry-pick of `48b2b723` from the market-data branch (PR #502) as a standalone hotfix.

**Why now:** the 90-day staleness guard on `protocolData.updatedAt` (`service.test.ts`) crossed its boundary 2026-08-13 — the 2026-05-15 stamp aged out, so **every CI run against main fails this test from today**, including Monday's hands-free weekly-refresh bot PR (it runs the full `pnpm test` battery). This must land before **Mon 2026-08-17 06:00 UTC** or the first hands-free proof run arrives with red CI on an unrelated failure.

**What it does:** combined TVL refreshed with live DeFiLlama parent aggregates (2026-08-13): Aave $14.8B + Sky $5.8B + Jupiter $1.5B + Sanctum $1.3B + Compound $1.2B + Jito $0.8B = $25.4B → "over $25 billion". The old $120B was the pre-drawdown February figure. Updated: `constants.ts` (combined + updatedAt + provenance comment) and the `protocols.json` `tvl.number` fallback + "Last verified" line ×4 locales.

Per-protocol card figures (e.g. Aave "~$35 billion") are registered separately as pending 5.93 — not guard-covered, next monthly refresh.

Founder merge consent given 2026-08-13 ("merge whatever is pending to be merged and put it live").

🤖 Generated with [Claude Code](https://claude.com/claude-code)