### PR TITLE
ci: one build retry — 5.88 Google-Fonts flake (pre-Monday)

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -39,7 +39,13 @@ jobs:
         # from workspace packages (@diboas/i18n, @diboas/ui, @diboas/email)
         # which must be built first; `pnpm --filter web build` skips them
         # and fails with Module not found. (First-CI-run bug fix, 2026-05-09.)
-        run: pnpm build
+        # 5.88 (2026-08-13, founder-approved after 3 same-day recurrences of the
+        # Google-Fonts build-time fetch flake — next/font/google refetches from
+        # fonts.gstatic.com on every cold runner; "Error while requesting
+        # resource" x9): one retry absorbs the transient fetch failure. Turbo
+        # cache makes the retry cheap (packages already built). The durable
+        # next/font/local option stays registered on 5.88 if flakes persist.
+        run: pnpm build || pnpm build
         env:
           NEXT_PUBLIC_APP_URL: 'http://localhost:3000'
           NEXT_PUBLIC_SITE_URL: 'http://localhost:3000'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,14 @@ jobs:
       - run: pnpm validate:seo
       - run: pnpm validate:ux-canon
       - run: pnpm check:ux-greps
-      - run: pnpm build
+      - name: Build (one retry for the 5.88 font-fetch flake)
+        # 5.88 (2026-08-13, founder-approved after 3 same-day recurrences of the
+        # Google-Fonts build-time fetch flake — next/font/google refetches from
+        # fonts.gstatic.com on every cold runner; "Error while requesting
+        # resource" x9): one retry absorbs the transient fetch failure. Turbo
+        # cache makes the retry cheap (packages already built). The durable
+        # next/font/local option stays registered on 5.88 if flakes persist.
+        run: pnpm build || pnpm build
       # Phase 5.2 (audit/2026-05-09): Turbopack-aware bundle-budget gate.
       # Replaces the original webpack-plugin enforcement (was inert under
       # Turbopack — see F1 audit). Walks `.next/static/chunks` for size /

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,13 @@ jobs:
         # from workspace packages (@diboas/i18n, @diboas/ui, @diboas/email)
         # which must be built first; `pnpm --filter web build` skips them
         # and fails with Module not found. (First-CI-run bug fix, 2026-05-09.)
-        run: pnpm build
+        # 5.88 (2026-08-13, founder-approved after 3 same-day recurrences of the
+        # Google-Fonts build-time fetch flake — next/font/google refetches from
+        # fonts.gstatic.com on every cold runner; "Error while requesting
+        # resource" x9): one retry absorbs the transient fetch failure. Turbo
+        # cache makes the retry cheap (packages already built). The durable
+        # next/font/local option stays registered on 5.88 if flakes persist.
+        run: pnpm build || pnpm build
         env:
           NEXT_PUBLIC_APP_URL: 'http://localhost:3000'
           NEXT_PUBLIC_SITE_URL: 'http://localhost:3000'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,7 +39,13 @@ jobs:
         # from workspace packages (@diboas/i18n, @diboas/ui, @diboas/email)
         # which must be built first; `pnpm --filter web build` skips them
         # and fails with Module not found. (First-CI-run bug fix, 2026-05-09.)
-        run: pnpm build
+        # 5.88 (2026-08-13, founder-approved after 3 same-day recurrences of the
+        # Google-Fonts build-time fetch flake — next/font/google refetches from
+        # fonts.gstatic.com on every cold runner; "Error while requesting
+        # resource" x9): one retry absorbs the transient fetch failure. Turbo
+        # cache makes the retry cheap (packages already built). The durable
+        # next/font/local option stays registered on 5.88 if flakes persist.
+        run: pnpm build || pnpm build
         env:
           # Stub out env vars that the build path validates but that we
           # don't need to talk to real services for performance auditing.


### PR DESCRIPTION
Three same-day recurrences (2026-08-13) of the `next/font/google` cold-runner fetch flake fired 5.88's revisit trigger; founder approved fixing before the Mon 2026-08-17 hands-free run. One retry on the build step in all four workflows (option 2 from the 5.88 row — workflows only; the durable `next/font/local` option stays registered if flakes persist).

Founder merge consent given 2026-08-13 ("move with your recommendations for everything").

🤖 Generated with [Claude Code](https://claude.com/claude-code)