### PR TITLE
fix(market): two gaps the post-merge audit found, both invisible from today's data

### DIFF
--- a/.github/workflows/market-refresh-weekly.yml
+++ b/.github/workflows/market-refresh-weekly.yml
@@ -76,7 +76,13 @@ jobs:
         run: |
           node apps/web/scripts/market-refresh/generate.mjs --check
           node scripts/check-market-data-jargon.mjs
-          pnpm --filter web exec vitest run src/lib/market-data
+          # analytics-sdk is included deliberately: the CHART PROVENANCE gate
+          # (5.127 — every published history point must reconcile to a real run
+          # day) lives in analytics-sdk/__tests__/fixtures.test.ts, not
+          # market-data. Without it the bot's pre-flight cannot see the one
+          # assertion that stops invented history, and a violation would only
+          # surface as red CI on the PR it had already opened. 53 tests, ~0.2s.
+          pnpm --filter web exec vitest run src/lib/market-data src/lib/analytics-sdk
 
       # B4(b) 2026-08-11: bot-created PRs (GITHUB_TOKEN) never trigger the main
       # CI, so its format:check does not run on the weekly PR — a formatting

--- a/apps/web/scripts/market-refresh/generate.mjs
+++ b/apps/web/scripts/market-refresh/generate.mjs
@@ -257,6 +257,13 @@ function signalSlots(sig, locale, prior) {
     gapAbsPrecise: gapAbsOf(v) != null ? num(gapAbsOf(v), locale, 2) : '',
     priorGapAbsPrecise:
       gapAbsOf(prior?.values) != null ? num(gapAbsOf(prior.values), locale, 2) : '',
+    // The prior LEVEL, for rates. A relative gap is the natural framing for an
+    // index (the dollar sat 0.67% above its trend) but ambiguous for a yield:
+    // "after sitting 3.83% above it" lands beside "4.42%" and "4.51%" and reads
+    // as a third level. The level itself is unambiguous and directly
+    // comparable. Found by simulating a MAC-02 flip, which today's all-holding
+    // data never exercises (self-audit 2026-08-24).
+    priorClosePrecise: prior?.values?.close != null ? num(prior.values.close, locale, 2) : '',
     rsiCur: v.rsiCurrent != null ? num(v.rsiCurrent, locale) : '',
     rsiPrev: v.rsiPrev != null ? num(v.rsiPrev, locale) : '',
     stochK: v.stochK != null ? num(v.stochK, locale) : '',

--- a/apps/web/scripts/market-refresh/templates/state-beats.json
+++ b/apps/web/scripts/market-refresh/templates/state-beats.json
@@ -147,16 +147,16 @@
         "de": "Die 10-jährige US-Rendite hält sich mit {closePrecise}% über ihrem 20-Wochen-Trend ({ema20Precise}%)."
       },
       "freshSupportive": {
-        "en": "The US 10 year at {closePrecise}% dropped below its own {ema20Precise}% trend, after sitting {priorGapAbsPrecise}% above it a week earlier.",
-        "pt-BR": "O juro americano de 10 anos, a {closePrecise}%, caiu abaixo da tendência de 20 semanas ({ema20Precise}%), depois de estar {priorGapAbsPrecise}% acima uma semana antes.",
-        "es": "El rendimiento estadounidense a 10 años, en {closePrecise}%, cayó por debajo de su tendencia de 20 semanas ({ema20Precise}%), tras estar un {priorGapAbsPrecise}% por encima una semana antes.",
-        "de": "Die 10-jährige US-Rendite fiel mit {closePrecise}% unter ihren 20-Wochen-Trend ({ema20Precise}%), nachdem sie eine Woche zuvor {priorGapAbsPrecise}% darüber lag."
+        "en": "The US 10 year at {closePrecise}% dropped below its own {ema20Precise}% trend, after sitting at {priorClosePrecise}% a week earlier.",
+        "pt-BR": "O juro americano de 10 anos, a {closePrecise}%, caiu abaixo da tendência de 20 semanas ({ema20Precise}%), depois de estar em {priorClosePrecise}% uma semana antes.",
+        "es": "El rendimiento estadounidense a 10 años, en {closePrecise}%, cayó por debajo de su tendencia de 20 semanas ({ema20Precise}%), tras estar en {priorClosePrecise}% una semana antes.",
+        "de": "Die 10-jährige US-Rendite fiel mit {closePrecise}% unter ihren 20-Wochen-Trend ({ema20Precise}%), nachdem sie eine Woche zuvor bei {priorClosePrecise}% lag."
       },
       "freshRestrictive": {
-        "en": "The US 10 year at {closePrecise}% rose back above its own {ema20Precise}% trend, after sitting {priorGapAbsPrecise}% below it a week earlier.",
-        "pt-BR": "O juro americano de 10 anos, a {closePrecise}%, voltou a superar a tendência de 20 semanas ({ema20Precise}%), depois de estar {priorGapAbsPrecise}% abaixo uma semana antes.",
-        "es": "El rendimiento estadounidense a 10 años, en {closePrecise}%, volvió a superar su tendencia de 20 semanas ({ema20Precise}%), tras estar un {priorGapAbsPrecise}% por debajo una semana antes.",
-        "de": "Die 10-jährige US-Rendite stieg mit {closePrecise}% wieder über ihren 20-Wochen-Trend ({ema20Precise}%), nachdem sie eine Woche zuvor {priorGapAbsPrecise}% darunter lag."
+        "en": "The US 10 year at {closePrecise}% rose back above its own {ema20Precise}% trend, after sitting at {priorClosePrecise}% a week earlier.",
+        "pt-BR": "O juro americano de 10 anos, a {closePrecise}%, voltou a superar a tendência de 20 semanas ({ema20Precise}%), depois de estar em {priorClosePrecise}% uma semana antes.",
+        "es": "El rendimiento estadounidense a 10 años, en {closePrecise}%, volvió a superar su tendencia de 20 semanas ({ema20Precise}%), tras estar en {priorClosePrecise}% una semana antes.",
+        "de": "Die 10-jährige US-Rendite stieg mit {closePrecise}% wieder über ihren 20-Wochen-Trend ({ema20Precise}%), nachdem sie eine Woche zuvor bei {priorClosePrecise}% lag."
       }
     },
     "MAC-03": {


### PR DESCRIPTION
Follow-up to #526, which merged before this commit landed on the branch. Both gaps only appear when you exercise a path this week's data never takes.

### 1. A rate's prior gap read as a level (copy defect, would have shipped)
Simulating a MAC-02 flip end to end produced:

> "The US 10 year at 4.42% dropped below its own 4.51% trend, after sitting **3.83% above** it a week earlier."

Three percentages, two meanings — 4.42 and 4.51 are levels, 3.83 is a relative gap and reads as a third level. Relative distance suits an **index**; a **rate** needs the level. Now: *"after sitting at 4.68% a week earlier."* New `priorClosePrecise` slot, four locales.

### 2. The chart provenance gate was outside the bot's pre-flight
The weekly workflow ran `vitest run src/lib/market-data`, but the 5.127 provenance assertion — the one gate that stops invented history — lives in `analytics-sdk/__tests__/fixtures.test.ts`. A violation would still have been caught, but only as red CI on a PR the bot had already opened. Gate now covers both paths (+53 tests, ~0.2s). Verified with the bot's exact command: **321 tests pass**.

### Next Monday, verified rather than assumed
Simulated the 2026-08-31 run with MAC-02 flipped: opening switched to the supportive variant, the moved beat fired, the fresh depth variant fired with the prior reading, pt-BR tracked correctly. Restored; tree byte-identical.

### Production
main's committed `state_view.lead.en` and the live rendered lead are character-identical.

Gates each run unfiltered with exit codes read: 1422 tests, type-check, lint, format, drift, translations — all 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)